### PR TITLE
pkg/dpl: ignore first line of header information

### DIFF
--- a/pkg/dpl/reader.go
+++ b/pkg/dpl/reader.go
@@ -32,6 +32,10 @@ func Read(path string) ([]*DPL, error) {
 
 	var out []*DPL
 	for _, txtLine := range lines {
+		if txtLine[1] == "Street_Address" {
+			continue // skip the headers
+		}
+
 		deniedPerson := &DPL{
 			Name:           txtLine[0],
 			StreetAddress:  txtLine[1],

--- a/pkg/dpl/reader_test.go
+++ b/pkg/dpl/reader_test.go
@@ -14,8 +14,8 @@ func TestDPL__read(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(dpls) == 0 {
-		t.Errorf("no DPL records parsed")
+	if len(dpls) != 546 {
+		t.Errorf("found %d DPL records", len(dpls))
 	}
 
 	if _, err := Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv")); err == nil {


### PR DESCRIPTION
I noticed this comes up from DPL's list, whoops. 

<img width="1136" alt="Screen Shot 2019-12-11 at 3 08 02 PM" src="https://user-images.githubusercontent.com/120951/70668312-0ec0b000-1c28-11ea-8c48-0662c55f2bd2.png">
