### PR TITLE
cmd/server: add admin route to debug indexed SDN information

### DIFF
--- a/cmd/server/debug_sdn.go
+++ b/cmd/server/debug_sdn.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	moovhttp "github.com/moov-io/base/http"
+
+	"github.com/go-kit/kit/log"
+)
+
+const (
+	debugSDNPath = "/debug/sdn/{sdnId}"
+)
+
+func debugSDNHandler(logger log.Logger, searcher *searcher) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sdnID := getSDNId(w, r)
+		if sdnID == "" {
+			return
+		}
+
+		if requestID := moovhttp.GetRequestID(r); requestID != "" {
+			logger.Log("admin", fmt.Sprintf("debug route for SDN=%s", sdnID), "requestID", requestID)
+		}
+
+		var response struct {
+			SDN   *SDN
+			Debug struct {
+				IndexedName     string `json:"indexedName"`
+				ParsedRemarksID string `json:"parsedRemarksId"`
+			} `json:"debug"`
+		}
+		response.SDN = searcher.debugSDN(sdnID)
+		if response.SDN != nil {
+			response.Debug.IndexedName = response.SDN.name
+			response.Debug.ParsedRemarksID = response.SDN.id
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}
+}

--- a/cmd/server/debug_sdn_test.go
+++ b/cmd/server/debug_sdn_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/moov-io/base"
+	"github.com/moov-io/base/admin"
+
+	"github.com/go-kit/kit/log"
+)
+
+func TestDebug__SDN(t *testing.T) {
+	svc := admin.NewServer(":0")
+	go svc.Listen()
+	defer svc.Shutdown()
+
+	svc.AddHandler(debugSDNPath, debugSDNHandler(log.NewNopLogger(), idSearcher))
+
+	req, _ := http.NewRequest("GET", "http://"+svc.BindAddr()+"/debug/sdn/22790", nil)
+	req.Header.Set("x-request-id", base.ID())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		bs, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("bogus status code: %s: %s", resp.Status, string(bs))
+	}
+
+	var response struct {
+		Debug struct {
+			IndexedName     string `json:"indexedName"`
+			ParsedRemarksID string `json:"parsedRemarksId"`
+		} `json:"debug"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+
+	if response.Debug.IndexedName != "nicolas maduro moros" {
+		t.Errorf("debug: indexed name: %v", response.Debug.IndexedName)
+	}
+	if response.Debug.ParsedRemarksID != "5892464" {
+		t.Errorf("got parsed ID: %s", response.Debug.ParsedRemarksID)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -146,6 +146,9 @@ func main() {
 	// Add manual data refresh endpoint
 	adminServer.AddHandler(manualRefreshPath, manualRefreshHandler(logger, searcher, downloadRepo))
 
+	// Add debug routes
+	adminServer.AddHandler(debugSDNPath, debugSDNHandler(logger, searcher))
+
 	// Initial download of data
 	if stats, err := searcher.refreshData(os.Getenv("INITIAL_DATA_DIRECTORY")); err != nil {
 		logger.Log("main", fmt.Sprintf("ERROR: failed to download/parse initial data: %v", err))

--- a/cmd/server/search.go
+++ b/cmd/server/search.go
@@ -208,12 +208,19 @@ func (s *searcher) TopAltNames(limit int, alt string) []Alt {
 }
 
 func (s *searcher) FindSDN(entityID string) *ofac.SDN {
+	if sdn := s.debugSDN(entityID); sdn != nil {
+		return sdn.SDN
+	}
+	return nil
+}
+
+func (s *searcher) debugSDN(entityID string) *SDN {
 	s.RLock()
 	defer s.RUnlock()
 
 	for i := range s.SDNs {
 		if s.SDNs[i].EntityID == entityID {
-			return s.SDNs[i].SDN
+			return s.SDNs[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
We're including several steps between parsing the agencies file and what results are returned for a query. To help debugging we're adding a route for SDN entries to show their unexported fields (indexed name, remarks id, etc). 

With lists that have unique ids for each entry this type of route works great, but not every list offers that.  