### PR TITLE
Skip sdn_comments.csv line if length != 2

### DIFF
--- a/pkg/ofac/reader.go
+++ b/pkg/ofac/reader.go
@@ -196,6 +196,9 @@ func csvSDNCommentsFile(path string) (*Results, error) {
 	// Loop through lines & turn into object
 	var out []*SDNComments
 	for _, csvLine := range lines {
+		if len(csvLine) != 2 {
+			continue
+		}
 		csvLine := replaceNull(csvLine)
 		out = append(out, &SDNComments{
 			EntityID:        csvLine[0],


### PR DESCRIPTION
We were seeing panics like this on occasion:

```
panic: runtime error: index out of range [1] with length 1
goroutine 1 [running]:
github.com/moov-io/watchman/pkg/ofac.csvSDNCommentsFile(0xc00054a540, 0x29, 0x0, 0x0, 0x0)
        /go/src/github.com/moov-io/watchman/pkg/ofac/reader.go:202 +0x58e
github.com/moov-io/watchman/pkg/ofac.Read(0xc00054a540, 0x29, 0x0, 0x0, 0x0)
        /go/src/github.com/moov-io/watchman/pkg/ofac/reader.go:43 +0x425
main.ofacRecords(0xd23fe0, 0xc00010f230, 0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/moov-io/watchman/cmd/server/download.go:119 +0x265
main.(*searcher).refreshData(0xc0001a0380, 0x0, 0x0, 0x0, 0xc0001b3e00, 0xc0001b8d50)
        /go/src/github.com/moov-io/watchman/cmd/server/download.go:165 +0x7e
main.main()
        /go/src/github.com/moov-io/watchman/cmd/server/main.go:154 +0xde5
```

I initially was going to return an error, but I saw that for other
similar files, watchman just skips the line.
