### PR TITLE
search: introduce EXACT_MATCH_FAVORITISM config to optionally boost match rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ PONG
 |-----|-----|-----|
 | `DATA_REFRESH_INTERVAL` | Interval for data redownload and reparse. `off` disables this refreshing. | 12h |
 | `INITIAL_DATA_DIRECTORY` | Directory filepath with initial files to use instead of downloading. Periodic downloads will replace the initial files. | Empty |
+| `EXACT_MATCH_FAVORITISM` | Extra weighting assigned to exact matches. | 0.0 |
 | `WEBHOOK_BATCH_SIZE` | How many watches to read from database per batch of async searches. | 100 |
 | `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
 | `BASE_PATH` | HTTP path to serve API and web UI from. | `/` |

--- a/cmd/server/issue326_test.go
+++ b/cmd/server/issue326_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIssue326(t *testing.T) {
+	india := precompute("Huawei Technologies India Private Limited")
+	investment := precompute("Huawei Technologies Investment Co. Ltd.")
+
+	// Cuba
+	score := jaroWinkler(precompute("Huawei Cuba"), precompute("Huawei"))
+	assert.Equal(t, score, 0.8055555555555556)
+
+	// India
+	score = jaroWinkler(india, precompute("Huawei"))
+	assert.Equal(t, score, 0.5592063492063492)
+	score = jaroWinkler(india, precompute("Huawei Technologies"))
+	assert.Equal(t, score, 0.7559523809523809)
+
+	// Investment
+	score = jaroWinkler(investment, precompute("Huawei"))
+	assert.Equal(t, score, 0.3788888888888889)
+	score = jaroWinkler(investment, precompute("Huawei Technologies"))
+	assert.Equal(t, score, 0.8041666666666667)
+}


### PR DESCRIPTION
This is the fist configuration option available to tweak match results which should help specific use-cases. Various entity names are better handled with a single word match. 

This change does allow match percentages to be above 100% now as the weighting isn't bounded. 

Issue: https://github.com/moov-io/watchman/issues/326