### PR TITLE
Fix build failure on port conflict

### DIFF
--- a/makefile
+++ b/makefile
@@ -118,7 +118,7 @@ clean-integration:
 	docker-compose rm -v -f
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
-	sudo systemctl stop mono
+	sudo kill -9 `sudo lsof -t -i:8084`
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
 

--- a/makefile
+++ b/makefile
@@ -114,8 +114,8 @@ cover-web:
 	go tool cover -html=cover.out
 
 clean-integration:
-	docker-compose kill
-	docker-compose rm -v -f
+	docker-compose down -v
+	docker container ls -a
 
 test-integration: clean-integration
 	docker-compose up -d

--- a/makefile
+++ b/makefile
@@ -118,7 +118,7 @@ clean-integration:
 	docker-compose rm -v -f
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
-	pkill mono # this service is occupying port 8084
+	sudo pkill mono # this service is occupying port 8084
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
 

--- a/makefile
+++ b/makefile
@@ -118,7 +118,7 @@ clean-integration:
 	docker-compose rm -v -f
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
-	sudo pkill mono # this service is occupying port 8084
+	sudo systemctl stop mono
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
 

--- a/makefile
+++ b/makefile
@@ -114,8 +114,11 @@ cover-web:
 	go tool cover -html=cover.out
 
 clean-integration:
-	docker-compose down -v
+	docker-compose kill
+	docker-compose rm -v -f
 	docker container ls -a
+	sudo lsof -i:8084 ## see a specific port such as 22 ##
+	sudo lsof -i -P -n | grep LISTEN
 
 test-integration: clean-integration
 	docker-compose up -d

--- a/makefile
+++ b/makefile
@@ -116,7 +116,9 @@ cover-web:
 clean-integration:
 	docker-compose kill
 	docker-compose rm -v -f
-	docker container ls -a
+	sudo lsof -i:8084 ## see a specific port such as 22 ##
+	sudo lsof -i -P -n | grep LISTEN
+	pkill mono # this service is occupying port 8084
 	sudo lsof -i:8084 ## see a specific port such as 22 ##
 	sudo lsof -i -P -n | grep LISTEN
 


### PR DESCRIPTION
See #336 

Port conflict causes makefile `test-integration` phony to fail.