### PR TITLE
cmd/server: filter as part of searching, not after the fact

### DIFF
--- a/cmd/server/filter.go
+++ b/cmd/server/filter.go
@@ -25,14 +25,28 @@ func buildFilterRequest(u *url.URL) filterRequest {
 	}
 }
 
-func filterSDNs(sdns []SDN, req filterRequest) []SDN {
+func filterSDNs(sdns []*SDN, req filterRequest) []*SDN {
 	if req.empty() {
 		// short-circuit and return if we have no filters
 		return sdns
 	}
 
-	var out []SDN
+	keeper := keepSDN(req)
+
+	var out []*SDN
 	for i := range sdns {
+		if keeper(sdns[i]) {
+			out = append(out, sdns[i])
+		}
+	}
+	return out
+}
+
+func keepSDN(req filterRequest) func(*SDN) bool {
+	return func(sdn *SDN) bool {
+		if req.empty() {
+			return true // short-circuit if we have no filters
+		}
 		// by default exclude the result (as at least one filter is non-empty)
 		keep := false
 
@@ -41,32 +55,28 @@ func filterSDNs(sdns []SDN, req filterRequest) []SDN {
 		//
 		// NOTE: If we add more filters don't forget to also add them in values.go
 		if req.sdnType != "" {
-			if sdns[i].SDNType != "" {
-				if strings.EqualFold(sdns[i].SDNType, req.sdnType) {
+			if sdn.SDNType != "" {
+				if strings.EqualFold(sdn.SDNType, req.sdnType) {
 					keep = true
 				}
 			} else {
 				// 'entity' is a special case value for ?sdnType in that it refers to a company or organization
 				// and not an individual, however OFAC's data files do not contain this value and we must infer
 				// it instead.
-				if sdns[i].SDNType == "" && strings.EqualFold(req.sdnType, "entity") {
+				if sdn.SDNType == "" && strings.EqualFold(req.sdnType, "entity") {
 					keep = true
 				} else {
-					continue // skip this SDN as the filter didn't match
+					return false // skip this SDN as the filter didn't match
 				}
 			}
 		}
 		if req.ofacProgram != "" {
-			for j := range sdns[i].Programs {
-				if strings.EqualFold(sdns[i].Programs[j], req.ofacProgram) {
+			for j := range sdn.Programs {
+				if strings.EqualFold(sdn.Programs[j], req.ofacProgram) {
 					keep = true
 				}
 			}
 		}
-
-		if keep {
-			out = append(out, sdns[i])
-		}
+		return keep
 	}
-	return out
 }

--- a/cmd/server/filter_test.go
+++ b/cmd/server/filter_test.go
@@ -49,7 +49,7 @@ func TestFilter__buildFilterRequest(t *testing.T) {
 }
 
 var (
-	filterableSDNs = []SDN{
+	filterableSDNs = []*SDN{
 		{
 			SDN: &ofac.SDN{
 				EntityID: "12",
@@ -67,7 +67,7 @@ var (
 			},
 		},
 	}
-	terrorGroupSDN = SDN{
+	terrorGroupSDN = &SDN{
 		SDN: &ofac.SDN{
 			EntityID: "13",
 			SDNName:  "Terror Group",
@@ -75,7 +75,7 @@ var (
 			Programs: []string{"SDGT"},
 		},
 	}
-	oneEmptySDNType = []SDN{
+	oneEmptySDNType = []*SDN{
 		{
 			SDN: &ofac.SDN{
 				EntityID: "12",
@@ -86,7 +86,7 @@ var (
 		},
 		terrorGroupSDN,
 	}
-	missingSDNType = []SDN{
+	missingSDNType = []*SDN{
 		{
 			SDN: &ofac.SDN{
 				EntityID: "14",
@@ -95,7 +95,7 @@ var (
 			},
 		},
 	}
-	missingProgram = []SDN{
+	missingProgram = []*SDN{
 		{
 			SDN: &ofac.SDN{
 				EntityID: "15",

--- a/cmd/server/issue115_test.go
+++ b/cmd/server/issue115_test.go
@@ -21,18 +21,21 @@ func TestIssue115__TopSDNs(t *testing.T) {
 
 	pipe := noLogPipeliner
 	s := newSearcher(log.NewNopLogger(), pipe, 1)
+	keeper := keepSDN(filterRequest{})
 
 	// Issue 115 (https://github.com/moov-io/watchman/issues/115) talks about how "george bush" is a false positive (90%) match against
 	// several other "George ..." records. This is too sensitive and so we need to tone that down.
 
 	// was 89.6% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "2680", SDNName: "HABBASH, George", SDNType: "INDIVIDUAL"}}, nil, pipe)
-	out := s.TopSDNs(1, 0.00, "george bush")
+
+	out := s.TopSDNs(1, 0.00, "george bush", keeper)
 	eql(t, "issue115: top SDN 2680", out[0].match, 0.732)
 
 	// was 88.3% match
 	s.SDNs = precomputeSDNs([]*ofac.SDN{{EntityID: "9432", SDNName: "CHIWESHE, George", SDNType: "INDIVIDUAL"}}, nil, pipe)
-	out = s.TopSDNs(1, 0.00, "george bush")
+
+	out = s.TopSDNs(1, 0.00, "george bush", keeper)
 	eql(t, "issue115: top SDN 18996", out[0].match, 0.764)
 
 	// another example
@@ -41,9 +44,9 @@ func TestIssue115__TopSDNs(t *testing.T) {
 		t.Errorf("s.SDNs[0].name=%s", s.SDNs[0].name)
 	}
 
-	out = s.TopSDNs(1, 0.00, "george bush")
+	out = s.TopSDNs(1, 0.00, "george w bush", keeper)
 	eql(t, "issue115: top SDN 0", out[0].match, 1.0)
 
-	out = s.TopSDNs(1, 0.00, "george w bush")
+	out = s.TopSDNs(1, 0.00, "george bush", keeper)
 	eql(t, "issue115: top SDN 0", out[0].match, 1.0)
 }

--- a/cmd/server/search_async.go
+++ b/cmd/server/search_async.go
@@ -72,6 +72,8 @@ func (s *searcher) spawnResearching(logger log.Logger, companyRepo companyReposi
 }
 
 func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo customerRepository) (*bytes.Buffer, error) {
+	keeper := keepSDN(filterRequest{})
+
 	// Perform a query (ID watches) or search (name watches) and encode the model in JSON for calling the webhook.
 	switch {
 	case w.customerID != "":
@@ -80,7 +82,7 @@ func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo c
 
 	case w.customerName != "":
 		s.logger.Log("search", fmt.Sprintf("async: name watch '%s' for customer %s found", w.customerName, w.id))
-		sdns := s.TopSDNs(5, 0.00, w.customerName)
+		sdns := s.TopSDNs(5, 0.00, w.customerName, keeper)
 		for j := range sdns {
 			if strings.EqualFold(sdns[j].SDNType, "individual") {
 				return getCustomerBody(s, w.id, sdns[j].EntityID, sdns[j].match, custRepo)
@@ -93,7 +95,7 @@ func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo c
 
 	case w.companyName != "":
 		s.logger.Log("search", fmt.Sprintf("async: name watch '%s' for company %s found", w.companyName, w.id))
-		sdns := s.TopSDNs(5, 0.00, w.companyName)
+		sdns := s.TopSDNs(5, 0.00, w.companyName, keeper)
 		for j := range sdns {
 			if !strings.EqualFold(sdns[j].SDNType, "individual") {
 				return getCompanyBody(s, w.id, sdns[j].EntityID, sdns[j].match, companyRepo)

--- a/cmd/server/search_benchmark_test.go
+++ b/cmd/server/search_benchmark_test.go
@@ -43,10 +43,11 @@ func BenchmarkSearch__DPs(b *testing.B) {
 func BenchmarkSearch__SDNs(b *testing.B) {
 	b.StopTimer()
 	searcher := createBenchmarkSearcher(b)
+	keeper := keepSDN(filterRequest{})
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		searcher.TopSDNs(10, 0.0, randomName())
+		searcher.TopSDNs(10, 0.0, randomName(), keeper)
 	}
 }
 

--- a/cmd/server/search_test.go
+++ b/cmd/server/search_test.go
@@ -280,8 +280,9 @@ func TestSearch_liveData(t *testing.T) {
 		{"Nicolas MADURO", 1.0},
 		{"nicolas maduro", 1.0},
 	}
+	keeper := keepSDN(filterRequest{})
 	for i := range cases {
-		sdns := searcher.TopSDNs(1, 0.00, cases[i].name)
+		sdns := searcher.TopSDNs(1, 0.00, cases[i].name, keeper)
 		if len(sdns) == 0 {
 			t.Errorf("name=%q got no results", cases[i].name)
 		}
@@ -441,7 +442,8 @@ func TestSearch__FindSDN(t *testing.T) {
 }
 
 func TestSearch__TopSDNs(t *testing.T) {
-	sdns := sdnSearcher.TopSDNs(1, 0.00, "Ayman ZAWAHIRI")
+	keeper := keepSDN(filterRequest{})
+	sdns := sdnSearcher.TopSDNs(1, 0.00, "Ayman ZAWAHIRI", keeper)
 	if len(sdns) == 0 {
 		t.Fatal("empty SDNs")
 	}


### PR DESCRIPTION
Let's pass a closure through to exclude results prior to accumulation. This allows us to return more accurate results.

Issue: https://github.com/moov-io/watchman/issues/349 