### PR TITLE
COR-462 Add match to client entities

### DIFF
--- a/api/client.yaml
+++ b/api/client.yaml
@@ -1052,6 +1052,10 @@ components:
           type: string
           description: The link for information regarding the source
           example: http://bit.ly/1MLgou0
+        match:
+          type: number
+          description: Match percentage of search query
+          example: 0.91
     BISEntities:
       description: Bureau of Industry and Security Entity List
       properties:
@@ -1095,6 +1099,10 @@ components:
           type: string
           description: The link for information regarding the source
           example: http://bit.ly/1MLgou0
+        match:
+          type: number
+          description: Match percentage of search query
+          example: 0.91
     UpdateOfacCompanyStatus:
       description: Request body to update a company status.
       properties:

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -1325,6 +1325,7 @@ components:
         - VERKHNECHONSKNEFTEGAZ
         - OJSC VERKHNECHONSKNEFTEGAZ
         name: PJSC VERKHNECHONSKNEFTEGAZ
+        match: 0.91
         ids:
         - Subject to Directive 4, Executive Order 13662 Directive Determination
         - vcng@rosneft.ru, Email Address
@@ -1398,6 +1399,10 @@ components:
           description: The link for information regarding the source
           example: http://bit.ly/1MLgou0
           type: string
+        match:
+          description: Match percentage of search query
+          example: 0.91
+          type: number
     BISEntities:
       description: Bureau of Industry and Security Entity List
       example:
@@ -1412,6 +1417,7 @@ components:
         - OJSC VERKHNECHONSKNEFTEGAZ
         licensePolicy: Presumption of denial.
         name: Luhansk People¬ís Republic
+        match: 0.91
         sourceListURL: http://bit.ly/1MLgou0
         startDate: 6/21/16
         frNotice: 81 FR 61595
@@ -1460,6 +1466,10 @@ components:
           description: The link for information regarding the source
           example: http://bit.ly/1MLgou0
           type: string
+        match:
+          description: Match percentage of search query
+          example: 0.91
+          type: number
     UpdateOfacCompanyStatus:
       description: Request body to update a company status.
       example:
@@ -1581,6 +1591,7 @@ components:
           - OJSC VERKHNECHONSKNEFTEGAZ
           licensePolicy: Presumption of denial.
           name: Luhansk People¬ís Republic
+          match: 0.91
           sourceListURL: http://bit.ly/1MLgou0
           startDate: 6/21/16
           frNotice: 81 FR 61595
@@ -1595,6 +1606,7 @@ components:
           - OJSC VERKHNECHONSKNEFTEGAZ
           licensePolicy: Presumption of denial.
           name: Luhansk People¬ís Republic
+          match: 0.91
           sourceListURL: http://bit.ly/1MLgou0
           startDate: 6/21/16
           frNotice: 81 FR 61595
@@ -1608,6 +1620,7 @@ components:
           - VERKHNECHONSKNEFTEGAZ
           - OJSC VERKHNECHONSKNEFTEGAZ
           name: PJSC VERKHNECHONSKNEFTEGAZ
+          match: 0.91
           ids:
           - Subject to Directive 4, Executive Order 13662 Directive Determination
           - vcng@rosneft.ru, Email Address
@@ -1629,6 +1642,7 @@ components:
           - VERKHNECHONSKNEFTEGAZ
           - OJSC VERKHNECHONSKNEFTEGAZ
           name: PJSC VERKHNECHONSKNEFTEGAZ
+          match: 0.91
           ids:
           - Subject to Directive 4, Executive Order 13662 Directive Determination
           - vcng@rosneft.ru, Email Address

--- a/client/docs/BisEntities.md
+++ b/client/docs/BisEntities.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **FrNotice** | **string** | Identifies the corresponding Notice in the Federal Register | [optional] 
 **SourceListURL** | **string** | The link to the official SSI list | [optional] 
 **SourceInfoURL** | **string** | The link for information regarding the source | [optional] 
+**Match** | **float32** | Match percentage of search query | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/docs/Ssi.md
+++ b/client/docs/Ssi.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **Ids** | **[]string** | IDs on file for the entity | [optional] 
 **SourceListURL** | **string** | The link to the official SSI list | [optional] 
 **SourceInfoURL** | **string** | The link for information regarding the source | [optional] 
+**Match** | **float32** | Match percentage of search query | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/client/model_bis_entities.go
+++ b/client/model_bis_entities.go
@@ -29,4 +29,6 @@ type BisEntities struct {
 	SourceListURL string `json:"sourceListURL,omitempty"`
 	// The link for information regarding the source
 	SourceInfoURL string `json:"sourceInfoURL,omitempty"`
+	// Match percentage of search query
+	Match float32 `json:"match,omitempty"`
 }

--- a/client/model_ssi.go
+++ b/client/model_ssi.go
@@ -30,4 +30,6 @@ type Ssi struct {
 	SourceListURL string `json:"sourceListURL,omitempty"`
 	// The link for information regarding the source
 	SourceInfoURL string `json:"sourceInfoURL,omitempty"`
+	// Match percentage of search query
+	Match float32 `json:"match,omitempty"`
 }


### PR DESCRIPTION
# Changes
- Added **match** to both `SectoralSanctions` and `BisEntities` in the client responses

# Why these changes are needed
- Currently both `SectorialSanctions` and `BisEntities` populate match in the service, but are not received when using the api client
- Adding these in allow consumers of the client to get the **match** data on a request