### PR TITLE
COR-643 Bugfix on alt names pre-compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.21.1 (Released 2021-09-29)
+
+Release v0.21.1 applies bugfix to pre-computation steps to SDN alternate names.
+
+BUG FIXES
+
+- search: bugfix for pipeline steps to SDN alt names (#376)
+
 ## v0.21.0 (Released 2021-09-29)
 
 Release v0.21.0 applies pre-computation steps to SDN alternate names which was previously missing. This impacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.21.1 (Released 2021-09-29)
+## v0.21.1 (Released 2021-10-04)
 
 Release v0.21.1 applies bugfix to pre-computation steps to SDN alternate names.
 

--- a/cmd/server/pipeline.go
+++ b/cmd/server/pipeline.go
@@ -25,6 +25,7 @@ type Name struct {
 	Processed string
 
 	// optional metadata of where a name came from
+	alt   *ofac.AlternateIdentity
 	sdn   *ofac.SDN
 	ssi   *csl.SSI
 	dp    *dpl.DPL
@@ -45,6 +46,7 @@ func altName(alt *ofac.AlternateIdentity) *Name {
 	return &Name{
 		Original:  alt.AlternateName,
 		Processed: alt.AlternateName,
+		alt:       alt,
 	}
 }
 

--- a/cmd/server/pipeline_stopwords.go
+++ b/cmd/server/pipeline_stopwords.go
@@ -33,11 +33,16 @@ var (
 type stopwordsStep struct{}
 
 func (s *stopwordsStep) apply(in *Name) error {
+	if in == nil {
+		return nil
+	}
+
 	switch {
 	case in.sdn != nil && !strings.EqualFold(in.sdn.SDNType, "individual"):
 		in.Processed = removeStopwords(in.Processed, detectLanguage(in.Processed, in.addrs))
-
 	case in.ssi != nil && !strings.EqualFold(in.ssi.Type, "individual"):
+		in.Processed = removeStopwords(in.Processed, detectLanguage(in.Processed, nil))
+	case in.alt != nil:
 		in.Processed = removeStopwords(in.Processed, detectLanguage(in.Processed, nil))
 	}
 	return nil

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -357,7 +357,7 @@ func TestSearch__AltName(t *testing.T) {
 		t.Errorf("bogus status code: %d", w.Code)
 	}
 
-	if v := w.Body.String(); !strings.Contains(v, `"match":0.666`) {
+	if v := w.Body.String(); !strings.Contains(v, `"match":0.5`) {
 		t.Error(v)
 	}
 

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package watchman
 
-const Version = "v0.21.0"
+const Version = "v0.22.1"

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package watchman
 
-const Version = "v0.22.0"
+const Version = "v0.21.0"

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@
 
 package watchman
 
-const Version = "v0.22.1"
+const Version = "v0.22.0"


### PR DESCRIPTION
# Changes 
- Updated `stopwordsStep.apply` to remove stopwards for an alt name
- Added in unit tests to confirm `stopwordsStep.apply`

# Why these changes are being made
- There was a small bug identified in the previous Pull request which actually prevented alt names from being pre-computed


# Testing
- Properly confirmed debug logs to confirm alt names are being updated
![Screen Shot 2021-10-04 at 1 31 18 PM](https://user-images.githubusercontent.com/18034425/135914273-1a121ba0-48e2-4d27-991f-c9272d20fd8e.png)
 
- Confirmed via UI that results are now lower as expected
<img width="1340" alt="Screen Shot 2021-10-04 at 1 45 03 PM" src="https://user-images.githubusercontent.com/18034425/135914525-dc511259-f8c6-46d3-8efd-5ca893cd322d.png">
