### PR TITLE
File Parsing: Skip malformed CSV Rows

### DIFF
--- a/pkg/csl/reader.go
+++ b/pkg/csl/reader.go
@@ -2,6 +2,7 @@ package csl
 
 import (
 	"encoding/csv"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -20,12 +21,20 @@ func Read(path string) (*CSL, error) {
 	var els []*EL
 	for {
 		record, err := reader.Read()
-		if err == io.EOF {
-			break
-		}
 		if err != nil {
-			continue
+			// reached the last line
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
+				continue
+			}
+			return nil, err
 		}
+
 		if len(record) <= 1 {
 			continue // skip empty records
 		}

--- a/pkg/dpl/reader_test.go
+++ b/pkg/dpl/reader_test.go
@@ -18,7 +18,12 @@ func TestDPL__read(t *testing.T) {
 		t.Errorf("found %d DPL records", len(dpls))
 	}
 
-	if _, err := Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv")); err == nil {
-		t.Error("expected error")
+	// this file is formatted incorrectly for DPL, so we expect all rows to be skipped
+	got, err := Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("found %d DPL records, wanted 0", len(got))
 	}
 }

--- a/pkg/ofac/reader.go
+++ b/pkg/ofac/reader.go
@@ -6,6 +6,7 @@ package ofac
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -77,11 +78,18 @@ func csvAddressFile(path string) (*Results, error) {
 	reader := csv.NewReader(f)
 	for {
 		record, err := reader.Read()
-		if err != nil && err == csv.ErrFieldCount {
-			continue
-		}
-		if err == io.EOF { // TODO(Adam): add max line count break here also
-			break
+		if err != nil {
+			// reached the last line
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
+				continue
+			}
+			return nil, err
 		}
 		if len(record) != 6 {
 			continue
@@ -114,11 +122,18 @@ func csvAlternateIdentityFile(path string) (*Results, error) {
 	reader := csv.NewReader(f)
 	for {
 		record, err := reader.Read()
-		if err != nil && err == csv.ErrFieldCount {
-			continue
-		}
-		if err == io.EOF { // TODO(adam)
-			break
+		if err != nil {
+			// reached the last line
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
+				continue
+			}
+			return nil, err
 		}
 		if len(record) != 5 {
 			continue
@@ -149,11 +164,18 @@ func csvSDNFile(path string) (*Results, error) {
 	reader := csv.NewReader(f)
 	for {
 		record, err := reader.Read()
-		if err != nil && err == csv.ErrFieldCount {
-			continue
-		}
-		if err == io.EOF { // TODO(Adam): add max line count break here also
-			break
+		if err != nil {
+			// reached the last line
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
+				continue
+			}
+			return nil, err
 		}
 		if len(record) != 12 {
 			continue
@@ -194,13 +216,17 @@ func csvSDNCommentsFile(path string) (*Results, error) {
 	for {
 		line, err := r.Read()
 		if err != nil {
-			if err == io.EOF {
+			// reached the last line
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			if err == csv.ErrFieldCount {
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
 				continue
 			}
-			return &Results{SDNComments: out}, nil
+			return nil, err
 		}
 		if len(line) != 2 {
 			continue


### PR DESCRIPTION
Every now and then a source file downloaded from sanctions sources contains a malformed row. This change ensures such a row doesn't cause Watchman to crash. Instead, malformed rows are skipped and the `Read()` functions will just move onto the next row.