### PR TITLE
build: try using hashicorp-forge/go-test-split-action to speedup tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,11 +43,12 @@ jobs:
         index: ${{ matrix.index }}
 
     - name: Run Tests (Linux)
+      if: runner.os == 'Linux'
       env:
         GOTEST_FLAGS: '-run "${{ steps.test_split.outputs.run}}"'
       run: make check
 
-    - name: Check (Non-Linux)
+    - name: Run Short Tests (Non-Linux)
       if: runner.os != 'Linux'
       env:
         GOTEST_FLAGS: '-short -run "${{ steps.test_split.outputs.run}}"'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # Settings for test_split
+        total_test_splits: [5]
+        index: [0, 1, 2, 3, 4]
+
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -27,22 +31,27 @@ jobs:
       if: runner.os == 'Windows'
       run: choco install -y make mingw
 
-    - name: Build
-      run: make build
-
     - name: Setup
       if: runner.os == 'Linux'
       run: docker-compose up -d mysql
 
-    - name: Check (Linux)
-      if: runner.os == 'Linux'
+    - name: Generate go test Slice
+      id: test_split
+      uses: hashicorp-forge/go-test-split-action@v1
+      with:
+        total: ${{ matrix.total_test_splits }}
+        index: ${{ matrix.index }}
+
+    - name: Run Tests (Linux)
+      env:
+        GOTEST_FLAGS: '-run "${{ steps.test_split.outputs.run}}"'
       run: make check
 
     - name: Check (Non-Linux)
       if: runner.os != 'Linux'
-      run: make check
       env:
-        GOTEST_FLAGS: "-short"
+        GOTEST_FLAGS: '-short -run "${{ steps.test_split.outputs.run}}"'
+      run: make check
 
     - name: Upload Code Coverage
       if: runner.os == 'Linux'
@@ -69,6 +78,9 @@ jobs:
         sudo systemctl disable mono-xsp4.service || true
         sudo systemctl stop mono-xsp4.service || true
         sudo killall mono || true
+
+    - name: Build Frontend
+      run: make build
 
     - name: Docker Build
       if: runner.os == 'Linux'

--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ ifeq ($(OS),Windows_NT)
 else
 	@wget -O lint-project.sh https://raw.githubusercontent.com/moov-io/infra/master/go/lint-project.sh
 	@chmod +x ./lint-project.sh
-	COVER_THRESHOLD=50.0 DISABLE_GITLEAKS=true ./lint-project.sh
+	DISABLE_GITLEAKS=true ./lint-project.sh
 endif
 
 .PHONY: admin


### PR DESCRIPTION
I found this action recently and think it can help split up Go tests by running them in parallel but separate from each other. 

See: https://github.com/hashicorp-forge/go-test-split-action

Edit: We're seeing a major improvement in tests. From 16mins to 5mins. 
Before: https://github.com/moov-io/watchman/actions/runs/4076502797
After: https://github.com/moov-io/watchman/actions/runs/4077961811