### PR TITLE
fix: filter SDNs in async search rather than truncate

### DIFF
--- a/cmd/server/search_async.go
+++ b/cmd/server/search_async.go
@@ -71,8 +71,6 @@ func (s *searcher) spawnResearching(logger log.Logger, companyRepo companyReposi
 }
 
 func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo customerRepository) (*bytes.Buffer, error) {
-	keeper := keepSDN(filterRequest{})
-
 	// Perform a query (ID watches) or search (name watches) and encode the model in JSON for calling the webhook.
 	switch {
 	case w.customerID != "":
@@ -81,6 +79,9 @@ func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo c
 
 	case w.customerName != "":
 		s.logger.Logf("async: name watch '%s' for customer %s found", w.customerName, w.id)
+		keeper := keepSDN(filterRequest{
+			sdnType: "individual",
+		})
 		sdns := s.TopSDNs(5, 0.00, w.customerName, keeper)
 		for j := range sdns {
 			if strings.EqualFold(sdns[j].SDNType, "individual") {
@@ -94,6 +95,9 @@ func (s *searcher) renderBody(w watch, companyRepo companyRepository, custRepo c
 
 	case w.companyName != "":
 		s.logger.Logf("async: name watch '%s' for company %s found", w.companyName, w.id)
+		keeper := keepSDN(filterRequest{
+			sdnType: "entity",
+		})
 		sdns := s.TopSDNs(5, 0.00, w.companyName, keeper)
 		for j := range sdns {
 			if !strings.EqualFold(sdns[j].SDNType, "individual") {


### PR DESCRIPTION
With some queries the top 5 SDNs wouldn't include a valid result. Instead we need to filter before limiting results.