### PR TITLE
fix: keep numbers during stopwords step

### DIFF
--- a/cmd/server/pipeline_company_name_cleanup_test.go
+++ b/cmd/server/pipeline_company_name_cleanup_test.go
@@ -51,6 +51,10 @@ func TestRemoveCompanyTitles(t *testing.T) {
 		{"MC OVERSEAS TRADING COMPANY SA DE CV", "MC OVERSEAS TRADING COMPANY"},                                // SDN 10252
 		{"SIRJANCO TRADING L.L.C.", "SIRJANCO TRADING"},                                                        // SDN 15985
 
+		// Issue 483
+		{"11420 CORP.", "11420 CORP."},
+		{"11,420.2-1 CORP.", "11,420.2-1 CORP."},
+
 		// Controls
 		{"TADBIR ECONOMIC DEVELOPMENT GROUP", "TADBIR ECONOMIC DEVELOPMENT GROUP"}, // SDN 16006
 		{"DI LAURO, Marco", "DI LAURO, Marco"},                                     // SDN 16128

--- a/cmd/server/pipeline_normalize_test.go
+++ b/cmd/server/pipeline_normalize_test.go
@@ -31,6 +31,9 @@ func TestPrecompute(t *testing.T) {
 		{"convert IAcute", "Delcy Rodríguez", "delcy rodriguez"},
 		{"issue 58", "Raúl Castro", "raul castro"},
 		{"remove hyphen", "ANGLO-CARIBBEAN ", "anglo caribbean"},
+		// Issue 483
+		{"issue 483 #1", "11420 CORP.", "11420 corp"},
+		{"issue 483 #2", "11,420.2-1 CORP.", "114202 1 corp"},
 	}
 	for i, tc := range tests {
 		guess := precompute(tc.input)

--- a/cmd/server/pipeline_reorder_test.go
+++ b/cmd/server/pipeline_reorder_test.go
@@ -49,4 +49,19 @@ func TestReorderSDNName(t *testing.T) {
 			t.Errorf("reorderSDNName(%q)=%q expected %q", cases[i].input, guess, cases[i].expected)
 		}
 	}
+
+	// Entities
+	cases = []struct {
+		input, expected string
+	}{
+		// Issue 483
+		{"11420 CORP.", "11420 CORP."},
+		{"11,420.2-1 CORP.", "11,420.2-1 CORP."},
+	}
+	for i := range cases {
+		guess := reorderSDNName(cases[i].input, "") // blank refers to a company
+		if guess != cases[i].expected {
+			t.Errorf("reorderSDNName(%q)=%q expected %q", cases[i].input, guess, cases[i].expected)
+		}
+	}
 }

--- a/cmd/server/pipeline_stopwords.go
+++ b/cmd/server/pipeline_stopwords.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -48,11 +49,29 @@ func (s *stopwordsStep) apply(in *Name) error {
 	return nil
 }
 
+var (
+	numberRegex = regexp.MustCompile(`([\d\.\,\-]{1,}[\d]{1,})`)
+)
+
 func removeStopwords(in string, lang whatlanggo.Lang) string {
 	if keepStopwords {
 		return in
 	}
-	return strings.TrimSpace(stopwords.CleanString(strings.ToLower(in), lang.Iso6391(), false))
+
+	var out []string
+	words := strings.Fields(strings.ToLower(in))
+	for i := range words {
+		cleaned := strings.TrimSpace(words[i])
+
+		// When the word is a number leave it alone
+		if !numberRegex.MatchString(cleaned) {
+			cleaned = strings.TrimSpace(stopwords.CleanString(cleaned, lang.Iso6391(), false))
+		}
+		if cleaned != "" {
+			out = append(out, cleaned)
+		}
+	}
+	return strings.Join(out, " ")
 }
 
 // detectLanguage will return a guess as to the appropriate language a given SDN's name

--- a/cmd/server/pipeline_stopwords_test.go
+++ b/cmd/server/pipeline_stopwords_test.go
@@ -72,7 +72,7 @@ func TestStopwords__clean(t *testing.T) {
 	for i := range cases {
 		result := removeStopwords(cases[i].in, cases[i].lang)
 		if result != cases[i].expected {
-			t.Errorf("\n#%d in=%q  lang=%v\ngot=%q", i, cases[i].in, cases[i].lang, result)
+			t.Errorf("\n#%d in=%q  lang=%v\n  got=%q\n  exp=%q", i, cases[i].in, cases[i].lang, result, cases[i].expected)
 		}
 	}
 }
@@ -112,6 +112,21 @@ func TestStopwords__apply(t *testing.T) {
 			testName: "ssi business",
 			in:       &Name{Processed: "Trees and Trucks", ssi: &csl.SSI{Type: "business"}},
 			expected: "trees trucks",
+		},
+		{
+			testName: "Issue 483 #1",
+			in:       &Name{Processed: "11420 CORP.", sdn: &ofac.SDN{SDNType: "business"}},
+			expected: "11420 corp",
+		},
+		{
+			testName: "Issue 483 #2",
+			in:       &Name{Processed: "11,420.2-1 CORP.", sdn: &ofac.SDN{SDNType: "business"}},
+			expected: "11,420.2-1 corp",
+		},
+		{
+			testName: "Issue 483 #3",
+			in:       &Name{Processed: "11AA420 CORP.", sdn: &ofac.SDN{SDNType: "business"}},
+			expected: "11aa420 corp",
 		},
 	}
 

--- a/cmd/server/pipeline_test.go
+++ b/cmd/server/pipeline_test.go
@@ -64,6 +64,11 @@ func TestFullPipeline(t *testing.T) {
 		{company("MKS INTERNATIONAL CO. LTD."), "mks international"},                                                    // SDN 21553
 		{company("SHANGHAI NORTH TRANSWAY INTERNATIONAL TRADING CO."), "shanghai north transway international trading"}, // SDN 22246
 
+		// Keep numbers
+		{company("11420 CORP."), "11420 corp"},
+		{company("11AA420 CORP."), "11aa420 corp"},
+		{company("11,420.2-1 CORP."), "114202 1 corp"},
+
 		// Remove stopwords
 		{company("INVERSIONES LA QUINTA Y CIA. LTDA."), "inversiones la quinta y cia"},
 


### PR DESCRIPTION
An issue noted that "11420 CORP" was being indexed as "corp" with the numbers removed. This is inaccurate as the numbers of a name are valuable.

Fixes: https://github.com/moov-io/watchman/issues/483