### PR TITLE
pass io.ReadCloser instances instead of files on harddrive, fixes #536

### DIFF
--- a/cmd/server/search_crypto_test.go
+++ b/cmd/server/search_crypto_test.go
@@ -7,8 +7,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,7 +27,11 @@ var (
 
 func init() {
 	// Set SDN Comments
-	ofacResults, err := ofac.Read(filepath.Join("..", "..", "test", "testdata", "sdn_comments.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "sdn_comments.csv"))
+	if err != nil {
+		panic(fmt.Sprintf("%v", err))
+	}
+	ofacResults, err := ofac.Read(map[string]io.ReadCloser{"sdn_comments.csv": fd})
 	if err != nil {
 		panic(fmt.Sprintf("ERROR reading sdn_comments.csv: %v", err))
 	}

--- a/cmd/server/search_handlers_bench_test.go
+++ b/cmd/server/search_handlers_bench_test.go
@@ -7,10 +7,12 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -56,7 +58,11 @@ func BenchmarkSearchHandler(b *testing.B) {
 }
 
 func BenchmarkJaroWinkler(b *testing.B) {
-	results, err := ofac.Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	if err != nil {
+		b.Error(err)
+	}
+	results, err := ofac.Read(map[string]io.ReadCloser{"sdn.csv": fd})
 	require.NoError(b, err)
 	require.Len(b, results.SDNs, 7379)
 

--- a/cmd/server/search_us_csl.go
+++ b/cmd/server/search_us_csl.go
@@ -39,6 +39,9 @@ func searchUSCSL(logger log.Logger, searcher *searcher) http.HandlerFunc {
 
 func precomputeCSLEntities[T any](items []*T, pipe *pipeliner) []*Result[T] {
 	out := make([]*Result[T], len(items))
+	if items == nil {
+		return out
+	}
 
 	for i, item := range items {
 		name := cslName(item)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673
 	go4.org v0.0.0-20230225012048-214862532bf5
 	golang.org/x/oauth2 v0.14.0
+	golang.org/x/sync v0.6.0
 	golang.org/x/text v0.14.0
 )
 
@@ -37,7 +38,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rickar/cal/v2 v2.1.13 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/pkg/csl/csl_test.go
+++ b/pkg/csl/csl_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestCSL(t *testing.T) {
-	t.Skip("CSL is currently broken, looks like they require API access now")
 
 	if testing.Short() {
 		t.Skip("ignorning network test")
@@ -27,7 +26,7 @@ func TestCSL(t *testing.T) {
 	file, err := Download(logger, dir)
 	require.NoError(t, err)
 
-	cslRecords, err := ReadFile(file)
+	cslRecords, err := ReadFile(file["csl.csv"])
 	require.NoError(t, err)
 
 	if len(cslRecords.SSIs) == 0 {

--- a/pkg/csl/download.go
+++ b/pkg/csl/download.go
@@ -6,6 +6,7 @@ package csl
 
 import (
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 
@@ -19,22 +20,18 @@ var (
 	usDownloadURL       = strx.Or(os.Getenv("CSL_DOWNLOAD_TEMPLATE"), os.Getenv("US_CSL_DOWNLOAD_URL"), publicUSDownloadURL)
 )
 
-func Download(logger log.Logger, initialDir string) (string, error) {
+func Download(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	cslURL, err := buildDownloadURL(usDownloadURL)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	cslNameAndSource := make(map[string]string)
 	cslNameAndSource["csl.csv"] = cslURL
 
-	file, err := dl.GetFiles(initialDir, cslNameAndSource)
-	if len(file) == 0 || err != nil {
-		return "", fmt.Errorf("csl download: %v", err)
-	}
-	return file[0], nil
+	return dl.GetFiles(initialDir, cslNameAndSource)
 }
 
 func buildDownloadURL(urlStr string) (string, error) {

--- a/pkg/csl/download_eu.go
+++ b/pkg/csl/download_eu.go
@@ -6,6 +6,7 @@ package csl
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/moov-io/base/log"
@@ -22,15 +23,12 @@ var (
 	euDownloadURL = strx.Or(os.Getenv("EU_CSL_DOWNLOAD_URL"), publicEUDownloadURL)
 )
 
-func DownloadEU(logger log.Logger, initialDir string) (string, error) {
+func DownloadEU(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	euCSLNameAndSource := make(map[string]string)
 	euCSLNameAndSource["eu_csl.csv"] = euDownloadURL
 
-	file, err := dl.GetFiles(initialDir, euCSLNameAndSource)
-	if len(file) == 0 || err != nil {
-		return "", fmt.Errorf("eu csl download: %v", err)
-	}
-	return file[0], nil
+	return dl.GetFiles(initialDir, euCSLNameAndSource)
+
 }

--- a/pkg/csl/download_eu_test.go
+++ b/pkg/csl/download_eu_test.go
@@ -6,6 +6,7 @@ package csl
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,18 +25,19 @@ func TestEUDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println("file in test: ", file)
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no EU CSL file")
 	}
-	defer os.RemoveAll(filepath.Dir(file))
 
-	if !strings.EqualFold("eu_csl.csv", filepath.Base(file)) {
-		t.Errorf("unknown file %s", file)
+	for fn := range file {
+		if !strings.EqualFold("eu_csl.csv", filepath.Base(fn)) {
+			t.Errorf("unknown file %s", file)
+		}
 	}
 }
 
 func TestEUDownload_initialDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "iniital-dir")
+	dir, err := os.MkdirTemp("", "initial-dir")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,19 +57,21 @@ func TestEUDownload_initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no EU CSL file")
 	}
 
-	if strings.EqualFold("eu_csl.csv", filepath.Base(file)) {
-		bs, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatal(err)
+	for fn, fd := range file {
+		if strings.EqualFold("eu_csl.csv", filepath.Base(fn)) {
+			bs, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := string(bs); v != "file=eu_csl.csv" {
+				t.Errorf("eu_csl.csv: %v", v)
+			}
+		} else {
+			t.Fatalf("unknown file: %v", file)
 		}
-		if v := string(bs); v != "file=eu_csl.csv" {
-			t.Errorf("eu_csl.csv: %v", v)
-		}
-	} else {
-		t.Fatalf("unknown file: %v", file)
 	}
 }

--- a/pkg/csl/download_test.go
+++ b/pkg/csl/download_test.go
@@ -5,6 +5,7 @@
 package csl
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,13 +23,14 @@ func TestDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no CSL file")
 	}
-	defer os.RemoveAll(filepath.Dir(file))
 
-	if !strings.EqualFold("csl.csv", filepath.Base(file)) {
-		t.Errorf("unknown file %s", file)
+	for fn := range file {
+		if !strings.EqualFold("csl.csv", filepath.Base(fn)) {
+			t.Errorf("unknown file %s", fn)
+		}
 	}
 }
 
@@ -55,20 +57,22 @@ func TestDownload_initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no CSL file")
 	}
 
-	if strings.EqualFold("csl.csv", filepath.Base(file)) {
-		bs, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatal(err)
+	for fn, fd := range file {
+		if strings.EqualFold("csl.csv", filepath.Base(fn)) {
+			bs, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := string(bs); v != "file=csl.csv" {
+				t.Errorf("csl.csv: %v", v)
+			}
+		} else {
+			t.Fatalf("unknown file: %v", file)
 		}
-		if v := string(bs); v != "file=csl.csv" {
-			t.Errorf("csl.csv: %v", v)
-		}
-	} else {
-		t.Fatalf("unknown file: %v", file)
 	}
 }
 

--- a/pkg/csl/download_uk.go
+++ b/pkg/csl/download_uk.go
@@ -5,7 +5,7 @@
 package csl
 
 import (
-	"fmt"
+	"io"
 	"os"
 
 	"github.com/moov-io/base/log"
@@ -23,28 +23,20 @@ var (
 	ukSanctionsListURL       = strx.Or(os.Getenv("UK_SANCTIONS_LIST_URL"), publicUKSanctionsListURL)
 )
 
-func DownloadUKCSL(logger log.Logger, initialDir string) (string, error) {
+func DownloadUKCSL(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	ukCSLNameAndSource := make(map[string]string)
 	ukCSLNameAndSource["ConList.csv"] = ukCSLDownloadURL
 
-	file, err := dl.GetFiles(initialDir, ukCSLNameAndSource)
-	if len(file) == 0 || err != nil {
-		return "", fmt.Errorf("uk csl download: %v", err)
-	}
-	return file[0], nil
+	return dl.GetFiles(initialDir, ukCSLNameAndSource)
 }
 
-func DownloadUKSanctionsList(logger log.Logger, initialDir string) (string, error) {
+func DownloadUKSanctionsList(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	ukSanctionsNameAndSource := make(map[string]string)
 	ukSanctionsNameAndSource["UK_Sanctions_List.ods"] = ukSanctionsListURL
 
-	file, err := dl.GetFiles(initialDir, ukSanctionsNameAndSource)
-	if len(file) == 0 || err != nil {
-		return "", fmt.Errorf("uk download: %v", err)
-	}
-	return file[0], nil
+	return dl.GetFiles(initialDir, ukSanctionsNameAndSource)
 }

--- a/pkg/csl/download_uk_test.go
+++ b/pkg/csl/download_uk_test.go
@@ -6,6 +6,7 @@ package csl
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,13 +25,14 @@ func TestUKCSLDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println("file in test: ", file)
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no UK CSL file")
 	}
-	defer os.RemoveAll(filepath.Dir(file))
 
-	if !strings.EqualFold("ConList.csv", filepath.Base(file)) {
-		t.Errorf("unknown file %s", file)
+	for fn := range file {
+		if !strings.EqualFold("ConList.csv", filepath.Base(fn)) {
+			t.Errorf("unknown file %s", file)
+		}
 	}
 }
 
@@ -55,20 +57,22 @@ func TestUKCSLDownload_initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no UK CSL file")
 	}
 
-	if strings.EqualFold("ConList.csv", filepath.Base(file)) {
-		bs, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatal(err)
+	for fn, fd := range file {
+		if strings.EqualFold("ConList.csv", filepath.Base(fn)) {
+			bs, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := string(bs); v != "file=ConList.csv" {
+				t.Errorf("ConList.csv: %v", v)
+			}
+		} else {
+			t.Fatalf("unknown file: %v", file)
 		}
-		if v := string(bs); v != "file=ConList.csv" {
-			t.Errorf("ConList.csv: %v", v)
-		}
-	} else {
-		t.Fatalf("unknown file: %v", file)
 	}
 }
 
@@ -82,13 +86,14 @@ func TestUKSanctionsListDownload(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println("file in test: ", file)
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no UK Sanctions List file")
 	}
-	defer os.RemoveAll(filepath.Dir(file))
 
-	if !strings.EqualFold("UK_Sanctions_List.ods", filepath.Base(file)) {
-		t.Errorf("unknown file %s", file)
+	for fn := range file {
+		if !strings.EqualFold("UK_Sanctions_List.ods", filepath.Base(fn)) {
+			t.Errorf("unknown file %s", file)
+		}
 	}
 }
 
@@ -113,19 +118,22 @@ func TestUKSanctionsListDownload_initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+
+	if len(file) == 0 {
 		t.Fatal("no UK Sanctions List file")
 	}
 
-	if strings.EqualFold("UK_Sanctions_List.ods", filepath.Base(file)) {
-		_, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatal(err)
+	for fn, fd := range file {
+		if strings.EqualFold("UK_Sanctions_List.ods", filepath.Base(fn)) {
+			_, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// if v := string(bs); v != "file=UK_Sanctions_List.ods" {
+			// 	t.Errorf("UK_Sanctions_List.ods: %v", v)
+			// }
+		} else {
+			t.Fatalf("unknown file: %v", file)
 		}
-		// if v := string(bs); v != "file=UK_Sanctions_List.ods" {
-		// 	t.Errorf("UK_Sanctions_List.ods: %v", v)
-		// }
-	} else {
-		t.Fatalf("unknown file: %v", file)
 	}
 }

--- a/pkg/csl/reader.go
+++ b/pkg/csl/reader.go
@@ -4,17 +4,14 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
-	"os"
 	"strings"
 )
 
-func ReadFile(path string) (*CSL, error) {
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, err
+func ReadFile(fd io.ReadCloser) (*CSL, error) {
+	if fd == nil {
+		return nil, errors.New("CSL file is empty or missing")
 	}
 	defer fd.Close()
-
 	return Parse(fd)
 }
 

--- a/pkg/csl/reader_eu.go
+++ b/pkg/csl/reader_eu.go
@@ -5,26 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 )
 
-func ReadEUFile(path string) ([]*EUCSLRecord, EUCSL, error) {
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, nil, err
+func ParseEU(r io.ReadCloser) ([]*EUCSLRecord, EUCSL, error) {
+	if r == nil {
+		return nil, nil, errors.New("EU CSL file is empty or missing")
 	}
-	defer fd.Close()
-
-	rows, rowsMap, err := ParseEU(fd)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return rows, rowsMap, nil
-}
-
-func ParseEU(r io.Reader) ([]*EUCSLRecord, EUCSL, error) {
+	defer r.Close()
 	reader := csv.NewReader(r)
 	// sets comma delim to ; and ignores " in non quoted field and size of columns
 	// https://stackoverflow.com/questions/31326659/golang-csv-error-bare-in-non-quoted-field

--- a/pkg/csl/reader_eu_test.go
+++ b/pkg/csl/reader_eu_test.go
@@ -1,6 +1,7 @@
 package csl
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -8,7 +9,11 @@ import (
 )
 
 func TestReadEU(t *testing.T) {
-	euCSL, euCSLMap, err := ReadEUFile(filepath.Join("..", "..", "test", "testdata", "eu_csl.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "eu_csl.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	euCSL, euCSLMap, err := ParseEU(fd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/csl/reader_test.go
+++ b/pkg/csl/reader_test.go
@@ -13,7 +13,11 @@ import (
 )
 
 func TestRead(t *testing.T) {
-	csl, err := ReadFile(filepath.Join("..", "..", "test", "testdata", "csl.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "csl.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	csl, err := ReadFile(fd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,8 +56,8 @@ func TestRead_missingRow(t *testing.T) {
 
 	_, err = fd.WriteString(`  \n invalid  \n  \n`)
 	require.NoError(t, err)
-
-	resp, err := ReadFile(fd.Name())
+	fd.Seek(0, 0)
+	resp, err := ReadFile(fd)
 	require.NoError(t, err)
 
 	require.Len(t, resp.ELs, 0)
@@ -62,7 +66,12 @@ func TestRead_missingRow(t *testing.T) {
 }
 
 func TestRead_invalidRow(t *testing.T) {
-	csl, err := ReadFile(filepath.Join("..", "..", "test", "testdata", "invalidFiles", "csl.csv"))
+
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "invalidFiles", "csl.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	csl, err := ReadFile(fd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,9 +403,9 @@ func Test__Issue326EL(t *testing.T) {
 	if err := fd.Sync(); err != nil {
 		t.Fatal(err)
 	}
-
+	fd.Seek(0, 0)
 	// read the line back
-	csl, err := ReadFile(fd.Name())
+	csl, err := ReadFile(fd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -452,8 +461,11 @@ func Test_expandProgramsList(t *testing.T) {
 func TestCSL__UniqueIDs(t *testing.T) {
 	// CSL datafiles have added a unique identifier as the first column.
 	// We need verify the old and new file formats can be parsed.
-
-	records, err := ReadFile(filepath.Join("..", "..", "test", "testdata", "csl-unique-ids.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "csl-unique-ids.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	records, err := ReadFile(fd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/csl/reader_uk.go
+++ b/pkg/csl/reader_uk.go
@@ -5,20 +5,15 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/knieriem/odf/ods"
 )
 
-func ReadUKCSLFile(path string) ([]*UKCSLRecord, UKCSL, error) {
-	if path == "" {
-		return nil, nil, errors.New("path was empty for ukcsl file")
-	}
-	fd, err := os.Open(path)
-	if err != nil {
-		return nil, nil, err
+func ReadUKCSLFile(fd io.ReadCloser) ([]*UKCSLRecord, UKCSL, error) {
+	if fd == nil {
+		return nil, nil, errors.New("uk CSL file is empty or missing")
 	}
 	defer fd.Close()
 
@@ -200,11 +195,16 @@ func unmarshalUKCSLRecord(csvRecord []string, ukCSLRecord *UKCSLRecord) {
 	}
 }
 
-func ReadUKSanctionsListFile(path string) ([]*UKSanctionsListRecord, UKSanctionsListMap, error) {
-	if path == "" {
-		return nil, nil, errors.New("path was empty for uk sanctions list file")
+func ReadUKSanctionsListFile(f io.ReadCloser) ([]*UKSanctionsListRecord, UKSanctionsListMap, error) {
+	if f == nil {
+		return nil, nil, errors.New("uk sanctions list file is empty or missing")
 	}
-	fd, err := ods.Open(path)
+	defer f.Close()
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	fd, err := ods.NewReader(bytes.NewReader(content), int64(len(content)))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/csl/reader_uk_test.go
+++ b/pkg/csl/reader_uk_test.go
@@ -2,6 +2,7 @@ package csl
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,7 +10,11 @@ import (
 )
 
 func TestReadUKCSL(t *testing.T) {
-	ukCSL, ukCSLMap, err := ReadUKCSLFile(filepath.Join("..", "..", "test", "testdata", "ConList.csv"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "ConList.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	ukCSL, ukCSLMap, err := ReadUKCSLFile(fd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,8 +76,13 @@ func TestReadUKCSL(t *testing.T) {
 
 func TestReadUKSanctionsList(t *testing.T) {
 	t.Setenv("WITH_UK_SANCTIONS_LIST", "false")
+
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "UK_Sanctions_List.ods"))
+	if err != nil {
+		t.Error(err)
+	}
 	// test we don't err on parsing the content
-	totalReport, report, err := ReadUKSanctionsListFile("../../test/testdata/UK_Sanctions_List.ods")
+	totalReport, report, err := ReadUKSanctionsListFile(fd)
 	assert.NoError(t, err)
 
 	// test that we get something more than an empty sanctions list record

--- a/pkg/dpl/download.go
+++ b/pkg/dpl/download.go
@@ -6,8 +6,8 @@ package dpl
 
 import (
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/watchman/pkg/download"
@@ -23,20 +23,11 @@ var (
 )
 
 // Download returns an array of absolute filepaths for files downloaded
-func Download(logger log.Logger, initialDir string) (string, error) {
+func Download(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	addrs := make(map[string]string)
 	addrs["dpl.txt"] = fmt.Sprintf(dplDownloadTemplate, "dpl.txt")
 
-	files, err := dl.GetFiles(initialDir, addrs)
-	if len(files) == 0 || err != nil {
-		return "", fmt.Errorf("dpl download: %v", err)
-	}
-	for i := range files {
-		if filepath.Base(files[i]) == "dpl.txt" {
-			return files[i], nil
-		}
-	}
-	return "", nil
+	return dl.GetFiles(initialDir, addrs)
 }

--- a/pkg/dpl/download_test.go
+++ b/pkg/dpl/download_test.go
@@ -26,7 +26,7 @@ func TestDownloader(t *testing.T) {
 	if len(file) == 0 {
 		t.Fatal("no DPL file")
 	}
-	for filename, _ := range file {
+	for filename := range file {
 		if !strings.EqualFold("dpl.txt", filepath.Base(filename)) {
 			t.Errorf("unknown file %s", file)
 		}

--- a/pkg/dpl/download_test.go
+++ b/pkg/dpl/download_test.go
@@ -5,6 +5,7 @@
 package dpl
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,13 +23,13 @@ func TestDownloader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no DPL file")
 	}
-	defer os.RemoveAll(filepath.Dir(file))
-
-	if !strings.EqualFold("dpl.txt", filepath.Base(file)) {
-		t.Errorf("unknown file %s", file)
+	for filename, _ := range file {
+		if !strings.EqualFold("dpl.txt", filepath.Base(filename)) {
+			t.Errorf("unknown file %s", file)
+		}
 	}
 }
 
@@ -54,19 +55,20 @@ func TestDownloader__initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if file == "" {
+	if len(file) == 0 {
 		t.Fatal("no DPL file")
 	}
-
-	if strings.EqualFold("dpl.txt", filepath.Base(file)) {
-		bs, err := os.ReadFile(file)
-		if err != nil {
-			t.Fatal(err)
+	for fn, fd := range file {
+		if strings.EqualFold("dpl.txt", filepath.Base(fn)) {
+			bs, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v := string(bs); v != "file=dpl.txt" {
+				t.Errorf("dpl.txt: %v", v)
+			}
+		} else {
+			t.Fatalf("unknown file: %v", file)
 		}
-		if v := string(bs); v != "file=dpl.txt" {
-			t.Errorf("dpl.txt: %v", v)
-		}
-	} else {
-		t.Fatalf("unknown file: %v", file)
 	}
 }

--- a/pkg/dpl/reader.go
+++ b/pkg/dpl/reader.go
@@ -8,17 +8,14 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
-	"os"
 )
 
 // Read parses DPL records from a TXT file and populates the associated arrays.
 //
 // For more details on the raw DPL files see https://moov-io.github.io/watchman/file-structure.html
-func Read(path string) ([]*DPL, error) {
-	// open txt file
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
+func Read(f io.ReadCloser) ([]*DPL, error) {
+	if f == nil {
+		return nil, errors.New("DPL file is empty or missing")
 	}
 	defer f.Close()
 

--- a/pkg/dpl/reader.go
+++ b/pkg/dpl/reader.go
@@ -28,19 +28,17 @@ func Read(f io.ReadCloser) ([]*DPL, error) {
 	for {
 		line, err := reader.Read()
 		if err != nil {
-			if err != nil {
-				// reached the last line
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				// malformed row
-				if errors.Is(err, csv.ErrFieldCount) ||
-					errors.Is(err, csv.ErrBareQuote) ||
-					errors.Is(err, csv.ErrQuote) {
-					continue
-				}
-				return nil, err
+			// reached the last line
+			if errors.Is(err, io.EOF) {
+				break
 			}
+			// malformed row
+			if errors.Is(err, csv.ErrFieldCount) ||
+				errors.Is(err, csv.ErrBareQuote) ||
+				errors.Is(err, csv.ErrQuote) {
+				continue
+			}
+			return nil, err
 		}
 
 		if len(line) < 12 || (len(line) >= 2 && line[1] == "Street_Address") {

--- a/pkg/dpl/reader_test.go
+++ b/pkg/dpl/reader_test.go
@@ -5,12 +5,17 @@
 package dpl
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestDPL__read(t *testing.T) {
-	dpls, err := Read(filepath.Join("..", "..", "test", "testdata", "dpl.txt"))
+	fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", "dpl.txt"))
+	if err != nil {
+		t.Error(err)
+	}
+	dpls, err := Read(fd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,7 +24,11 @@ func TestDPL__read(t *testing.T) {
 	}
 
 	// this file is formatted incorrectly for DPL, so we expect all rows to be skipped
-	got, err := Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	fd, err = os.Open(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	if err != nil {
+		t.Error(err)
+	}
+	got, err := Read(fd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ofac/download.go
+++ b/pkg/ofac/download.go
@@ -6,6 +6,7 @@ package ofac
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/moov-io/base/log"
@@ -28,7 +29,7 @@ var (
 	}()
 )
 
-func Download(logger log.Logger, initialDir string) ([]string, error) {
+func Download(logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
 	dl := download.New(logger, download.HTTPClient)
 
 	addrs := make(map[string]string)

--- a/pkg/ofac/download_test.go
+++ b/pkg/ofac/download_test.go
@@ -21,13 +21,12 @@ func TestDownloader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(filepath.Dir(files[0]))
 
 	if len(files) != 4 {
 		t.Errorf("OFAC: found %d files", len(files))
 	}
-	for i := range files {
-		name := filepath.Base(files[i])
+	for fn, _ := range files {
+		name := filepath.Base(fn)
 		switch name {
 		case "add.csv", "alt.csv", "sdn.csv", "sdn_comments.csv":
 			continue
@@ -59,10 +58,10 @@ func TestDownloader__initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := range files {
-		switch filepath.Base(files[i]) {
+	for fn, _ := range files {
+		switch filepath.Base(fn) {
 		case "sdn.txt":
-			bs, err := os.ReadFile(files[i])
+			bs, err := os.ReadFile(fn)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/ofac/download_test.go
+++ b/pkg/ofac/download_test.go
@@ -25,7 +25,7 @@ func TestDownloader(t *testing.T) {
 	if len(files) != 4 {
 		t.Errorf("OFAC: found %d files", len(files))
 	}
-	for fn, _ := range files {
+	for fn := range files {
 		name := filepath.Base(fn)
 		switch name {
 		case "add.csv", "alt.csv", "sdn.csv", "sdn_comments.csv":
@@ -58,7 +58,7 @@ func TestDownloader__initialDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for fn, _ := range files {
+	for fn := range files {
 		switch filepath.Base(fn) {
 		case "sdn.txt":
 			bs, err := os.ReadFile(fn)

--- a/pkg/ofac/reader_test.go
+++ b/pkg/ofac/reader_test.go
@@ -5,6 +5,7 @@
 package ofac
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,28 +16,35 @@ import (
 
 // TestOFAC__read validates reading an OFAC Address CSV File
 func TestOFAC__read(t *testing.T) {
-	res, err := Read(filepath.Join("..", "..", "test", "testdata", "add.csv"))
+	testdata := func(fn string) map[string]io.ReadCloser {
+		fd, err := os.Open(filepath.Join("..", "..", "test", "testdata", fn))
+		if err != nil {
+			t.Error(err)
+		}
+		return map[string]io.ReadCloser{fn: fd}
+	}
+	res, err := Read(testdata("add.csv"))
 	require.NoError(t, err)
 	require.Len(t, res.Addresses, 11696)
 	require.Len(t, res.AlternateIdentities, 0)
 	require.Len(t, res.SDNs, 0)
 	require.Len(t, res.SDNComments, 0)
 
-	res, err = Read(filepath.Join("..", "..", "test", "testdata", "alt.csv"))
+	res, err = Read(testdata("alt.csv"))
 	require.NoError(t, err)
 	require.Len(t, res.Addresses, 0)
 	require.Len(t, res.AlternateIdentities, 9682)
 	require.Len(t, res.SDNs, 0)
 	require.Len(t, res.SDNComments, 0)
 
-	res, err = Read(filepath.Join("..", "..", "test", "testdata", "sdn.csv"))
+	res, err = Read(testdata("sdn.csv"))
 	require.NoError(t, err)
 	require.Len(t, res.Addresses, 0)
 	require.Len(t, res.AlternateIdentities, 0)
 	require.Len(t, res.SDNs, 7379)
 	require.Len(t, res.SDNComments, 0)
 
-	res, err = Read(filepath.Join("..", "..", "test", "testdata", "sdn_comments.csv"))
+	res, err = Read(testdata("sdn_comments.csv"))
 	require.NoError(t, err)
 	require.Len(t, res.Addresses, 0)
 	require.Len(t, res.AlternateIdentities, 0)
@@ -98,9 +106,9 @@ func TestSDNComments(t *testing.T) {
 	if _, err := fd.WriteString(`28264,"hone Number 8613314257947; alt. Phone Number 8618004121000; Identification Number 210302198701102136 (China); a.k.a. "blackjack1987"; a.k.a. "khaleesi"; Linked To: LAZARUS GROUP."`); err != nil {
 		t.Fatal(err)
 	}
-
+	fd.Seek(0, 0)
 	// read with lazy quotes enabled
-	if res, err := csvSDNCommentsFile(fd.Name()); err != nil {
+	if res, err := csvSDNCommentsFile(fd); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	} else {
 		if len(res.SDNComments) != 1 {
@@ -118,8 +126,8 @@ func TestSDNComments_CryptoCurrencies(t *testing.T) {
 
 	_, err = fd.WriteString(`42496," alt. Digital Currency Address - XBT 12jVCWW1ZhTLA5yVnroEJswqKwsfiZKsax; alt. Digital Currency Address - XBT 1J378PbmTKn2sEw6NBrSWVfjZLBZW3DZem; alt. Digital Currency Address - XBT 18aqbRhHupgvC9K8qEqD78phmTQQWs7B5d; alt. Digital Currency Address - XBT 16ti2EXaae5izfkUZ1Zc59HMcsdnHpP5QJ; Secondary sanctions risk: North Korea Sanctions Regulations, sections 510.201 and 510.210; Transactions Prohibited For Persons Owned or Controlled By U.S. Financial Institutions: North Korea Sanctions Regulations section 510.214; Passport E59165201 (China) expires 01 Sep 2025; Identification Number 371326198812157611 (China); a.k.a. 'WAKEMEUPUPUP'; a.k.a. 'FAST4RELEASE'; Linked To: LAZARUS GROUP."`)
 	require.NoError(t, err)
-
-	sdn, err := csvSDNCommentsFile(fd.Name())
+	fd.Seek(0, 0)
+	sdn, err := csvSDNCommentsFile(fd)
 	require.NoError(t, err)
 	require.Len(t, sdn.SDNComments, 1)
 


### PR DESCRIPTION
- before each list Downloader was creating temporary with files on disk that were subsequently read in by the list Parser
- this changes this "communication" to io.ReadCloser which is more ideomatic in Go
- fixes #536 as no temporary files clutter the disk any more
