### PR TITLE
  Download all files if the initial dir does not exist. fixes #538

### DIFF
--- a/cmd/server/download.go
+++ b/cmd/server/download.go
@@ -273,6 +273,9 @@ func (s *searcher) refreshData(initialDir string) (*DownloadStats, error) {
 		lastDataRefreshFailure.WithLabelValues("SDNs").Set(float64(time.Now().Unix()))
 		stats.Errors = append(stats.Errors, fmt.Errorf("OFAC: %v", err))
 	}
+	if results == nil {
+		results = &ofac.Results{}
+	}
 
 	sdns := precomputeSDNs(results.SDNs, results.Addresses, s.pipe)
 	adds := precomputeAddresses(results.Addresses)

--- a/pkg/download/client.go
+++ b/pkg/download/client.go
@@ -60,10 +60,8 @@ func (dl *Downloader) GetFiles(dir string, namesAndSources map[string]string) (m
 	}
 
 	// Check the initial directory for files we don't need to download
-	localFiles, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("readdir %s: %v", dir, err)
-	}
+	// do not treat an nonexisting directory as error
+	localFiles, _ := os.ReadDir(dir)
 
 	var mu sync.Mutex
 	out := make(map[string]io.ReadCloser)


### PR DESCRIPTION
Workaround panic from nil dereference in error case
fixes **regression** in v0.28.1