### PR TITLE
fix: normalize Country once

### DIFF
--- a/internal/search/api_search.go
+++ b/internal/search/api_search.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/base/strx"
 	"github.com/moov-io/base/telemetry"
+	"github.com/moov-io/watchman/internal/country"
 	"github.com/moov-io/watchman/internal/postalpool"
 	"github.com/moov-io/watchman/internal/prepare"
 	"github.com/moov-io/watchman/pkg/address"
@@ -287,12 +288,14 @@ func readAddresses(ctx context.Context, addressParsingPool *postalpool.Service, 
 			addr, err := addressParsingPool.ParseAddress(ctx, input)
 			if err == nil {
 				out[idx] = addr
-				continue
 			}
+		} else {
+			// Fallback to standard parsing
+			out[idx] = address.ParseAddress(input)
 		}
 
-		// Fallback to standard parsing
-		out[idx] = address.ParseAddress(input)
+		// Normalize the country
+		out[idx].Country = country.Normalize(out[idx].Country)
 	}
 
 	return out

--- a/internal/search/api_search_test.go
+++ b/internal/search/api_search_test.go
@@ -136,7 +136,7 @@ func TestAPI_readSearchRequest(t *testing.T) {
 			City:       "ACMETOWN",
 			PostalCode: "54321",
 			State:      "KY",
-			Country:    "UNITED STATES",
+			Country:    "United States",
 		}
 		require.Len(t, query.Addresses, 1)
 		require.Equal(t, expected, query.Addresses[0])

--- a/pkg/csl_us/mapper.go
+++ b/pkg/csl_us/mapper.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moov-io/watchman/internal/country"
 	"github.com/moov-io/watchman/internal/prepare"
 	"github.com/moov-io/watchman/pkg/csl_us/gen/ENHANCED_XML"
 	"github.com/moov-io/watchman/pkg/search"
@@ -362,7 +363,7 @@ func mapAddresses(addresses *ENHANCED_XML.EntityAddresses) []search.Address {
 			}
 		}
 		if addr.Country != nil {
-			mappedAddr.Country = cmp.Or(mappedAddr.Country, addr.Country.Text)
+			mappedAddr.Country = country.Normalize(cmp.Or(mappedAddr.Country, addr.Country.Text))
 		}
 
 		if mappedAddr.Line1 != "" && mappedAddr.Country != "" {

--- a/pkg/ofac/mapper.go
+++ b/pkg/ofac/mapper.go
@@ -233,7 +233,7 @@ func parseAddresses(inputs []Address) []search.Address {
 		// {... Address:"place du Lac 2", CityStateProvincePostalCode:"Geneve 1204", Country:"Switzerland", AddressRemarks:""}
 		var addr search.Address
 		addr.Line1 = inputs[i].Address
-		addr.Country = inputs[i].Country
+		addr.Country = country.Normalize(inputs[i].Country)
 
 		parts := strings.Fields(inputs[i].CityStateProvincePostalCode)
 		if len(parts) == 1 {

--- a/pkg/search/similarity_address.go
+++ b/pkg/search/similarity_address.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/moov-io/iso3166"
 	"github.com/moov-io/watchman/internal/stringscore"
 )
 
@@ -23,7 +22,7 @@ func compareAddresses[Q any, I any](w io.Writer, query Entity[Q], index Entity[I
 	var scores []float64
 
 	if w != nil {
-		debug(w, "Address Comparison Details:\n")
+		debug(w, "address comparison details: query=%d  index=%d\n", len(query.Addresses), len(index.Addresses))
 	}
 
 	// Compare addresses
@@ -133,9 +132,8 @@ func compareAddress(w io.Writer, query, index Address) float64 {
 
 	// Compare country
 	if query.Country != "" && index.Country != "" {
-		queryCountryCode := findCountryCode(query.Country)
-		indexCountryCode := findCountryCode(index.Country)
-		match := strings.EqualFold(queryCountryCode, indexCountryCode)
+		// We assume the query and index Country fields are normalized before Similarity
+		match := strings.EqualFold(query.Country, index.Country)
 		score := boolToScore(match)
 		totalScore += score * countryWeight
 		totalWeight += countryWeight
@@ -158,20 +156,4 @@ func compareAddress(w io.Writer, query, index Address) float64 {
 			finalScore, totalScore, totalWeight)
 	}
 	return finalScore
-}
-
-func findCountryCode(country string) string {
-	// If country is a valid iso3166 code, return it
-	if iso3166.Valid(country) {
-		return country
-	}
-
-	// Otherwise if we can lookup the code return that.
-	code := iso3166.LookupCode(country)
-	if code != "" {
-		return code
-	}
-
-	// Return the original input otherwise
-	return country
 }


### PR DESCRIPTION
Each .Country field in a query can be normalized before search and each index's .Country can be normalized in the mapper.

<details>
<summary>Benchmarks</summary>

```
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz

                                │ ./pkg/search/before.txt │        ./pkg/search/after.txt        │
                                │         sec/op          │    sec/op     vs base                │
API_Search/normal-16                         23.65m ± ∞ ¹   23.36m ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-16                          65.77m ± ∞ ¹   50.99m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-16                83.87m ± ∞ ¹   72.03m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/3-16                33.34m ± ∞ ¹   31.47m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/5-16                25.91m ± ∞ ¹   24.06m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/10-16               22.25m ± ∞ ¹   20.33m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/20-16               17.93m ± ∞ ¹   16.28m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/25-16               18.20m ± ∞ ¹   16.65m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/50-16               16.76m ± ∞ ¹   15.94m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-16              15.28m ± ∞ ¹   14.91m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/150-16              15.17m ± ∞ ¹   16.50m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/200-16              15.32m ± ∞ ¹   16.98m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/250-16              19.42m ± ∞ ¹   17.49m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-16                21.40m ± ∞ ¹   18.66m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      23.93m         22.35m        -6.60%

                                │ ./pkg/search/before.txt │        ./pkg/search/after.txt         │
                                │          B/op           │     B/op       vs base                │
API_Search/normal-16                        8.602Mi ± ∞ ¹   8.589Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-16                         48.47Mi ± ∞ ¹   51.86Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-16               7.136Mi ± ∞ ¹   7.136Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/3-16               7.136Mi ± ∞ ¹   7.136Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/5-16               7.136Mi ± ∞ ¹   7.136Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/10-16              7.137Mi ± ∞ ¹   7.137Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/20-16              7.138Mi ± ∞ ¹   7.138Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/25-16              7.138Mi ± ∞ ¹   7.138Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/50-16              7.142Mi ± ∞ ¹   7.141Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-16             7.146Mi ± ∞ ¹   7.146Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/150-16             7.150Mi ± ∞ ¹   7.150Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/200-16             7.155Mi ± ∞ ¹   7.155Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/250-16             7.160Mi ± ∞ ¹   7.159Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-16               7.138Mi ± ∞ ¹   7.138Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                     8.299Mi         8.338Mi        +0.47%

                                │ ./pkg/search/before.txt │        ./pkg/search/after.txt        │
                                │        allocs/op        │  allocs/op    vs base                │
API_Search/normal-16                         447.8k ± ∞ ¹   447.8k ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-16                          659.4k ± ∞ ¹   660.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-16                365.4k ± ∞ ¹   365.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/3-16                365.4k ± ∞ ¹   365.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/5-16                365.4k ± ∞ ¹   365.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/10-16               365.4k ± ∞ ¹   365.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/20-16               365.5k ± ∞ ¹   365.5k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/25-16               365.5k ± ∞ ¹   365.5k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/50-16               365.5k ± ∞ ¹   365.5k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-16              365.6k ± ∞ ¹   365.6k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/150-16              365.7k ± ∞ ¹   365.7k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/200-16              365.8k ± ∞ ¹   365.8k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/250-16              365.9k ± ∞ ¹   365.9k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-16                365.5k ± ∞ ¹   365.5k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                      386.9k         386.9k        +0.01%

pkg: github.com/moov-io/watchman/pkg/search
                                     │ ./pkg/search/before.txt │        ./pkg/search/after.txt         │
                                     │         sec/op          │    sec/op     vs base                 │
DebugSimilarity/individuals-16                    29.96µ ± ∞ ¹   10.32µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/individuals-debug-16              56.22µ ± ∞ ¹   34.91µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-16                    14.050µ ± ∞ ¹   6.668µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-debug-16               36.11µ ± ∞ ¹   26.06µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/vessels-16                        2.736µ ± ∞ ¹   2.544µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/vessels-debug-16                  17.40µ ± ∞ ¹   16.40µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/aircraft-16                      121.86µ ± ∞ ¹   39.69µ ± ∞ ¹        ~ (p=1.000 n=1) ²
DebugSimilarity/aircraft-debug-16                203.77µ ± ∞ ¹   96.31µ ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                           31.66µ         17.78µ        -43.85%

                                     │ ./pkg/search/before.txt │        ./pkg/search/after.txt         │
                                     │          B/op           │     B/op       vs base                │
DebugSimilarity/individuals-16                   1.734Ki ± ∞ ¹   1.688Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/individuals-debug-16             8.329Ki ± ∞ ¹   8.281Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-16                    1.199Ki ± ∞ ¹   1.172Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-debug-16              7.551Ki ± ∞ ¹   7.520Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/vessels-16                         184.0 ± ∞ ¹     184.0 ± ∞ ¹       ~ (p=1.000 n=1) ³
DebugSimilarity/vessels-debug-16                 6.335Ki ± ∞ ¹   6.334Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/aircraft-16                      6.969Ki ± ∞ ¹   6.734Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/aircraft-debug-16                20.57Ki ± ∞ ¹   20.32Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                          3.477Ki         3.430Ki        -1.33%

                                     │ ./pkg/search/before.txt │       ./pkg/search/after.txt        │
                                     │        allocs/op        │  allocs/op   vs base                │
DebugSimilarity/individuals-16                     135.0 ± ∞ ¹   129.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/individuals-debug-16               190.0 ± ∞ ¹   184.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-16                      72.00 ± ∞ ¹   70.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/businesses-debug-16                107.0 ± ∞ ¹   105.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/vessels-16                         16.00 ± ∞ ¹   16.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
DebugSimilarity/vessels-debug-16                   34.00 ± ∞ ¹   34.00 ± ∞ ¹       ~ (p=1.000 n=1) ³
DebugSimilarity/aircraft-16                        496.0 ± ∞ ¹   476.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
DebugSimilarity/aircraft-debug-16                  631.0 ± ∞ ¹   611.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                            116.4         113.5        -2.44%
```

</details>

![Screenshot 2025-02-14 at 13 38 16](https://github.com/user-attachments/assets/141f6255-5c41-434a-aab2-22706233b259)
![Screenshot 2025-02-14 at 13 38 41](https://github.com/user-attachments/assets/9ef20889-a559-4db7-bdb9-990e49220935)
