### PR TITLE
postalpool: better pooling by default, offer configurable knobs

### DIFF
--- a/internal/postalpool/config.go
+++ b/internal/postalpool/config.go
@@ -1,6 +1,8 @@
 package postalpool
 
 import (
+	"net"
+	"net/http"
 	"time"
 )
 
@@ -12,6 +14,9 @@ type Config struct {
 	StartupTimeout time.Duration
 
 	RequestTimeout time.Duration
+
+	Dialer    *net.Dialer
+	Transport *http.Transport
 
 	BinaryPath string
 }

--- a/internal/postalpool/config_test.go
+++ b/internal/postalpool/config_test.go
@@ -1,0 +1,41 @@
+package postalpool_test
+
+import (
+	"embed"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/config"
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/postalpool"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed testdata/configs/config.default.yml
+	configFS embed.FS
+)
+
+func TestConfig(t *testing.T) {
+	logger := log.NewTestLogger()
+	configService := config.NewService(logger)
+
+	// strip ./testdata/
+	fsys, err := fs.Sub(configFS, "testdata")
+	require.NoError(t, err)
+
+	var config postalpool.Config
+	err = configService.LoadFromFS(&config, fsys)
+	require.NoError(t, err)
+
+	require.True(t, config.Enabled)
+	require.Equal(t, 2, config.Instances)
+	require.Equal(t, 10000, config.StartingPort)
+	require.Equal(t, 60*time.Second, config.StartupTimeout)
+	require.Equal(t, 10*time.Second, config.RequestTimeout)
+	require.NotNil(t, config.Dialer)
+	require.NotNil(t, config.Transport)
+	require.Equal(t, "/bin/postal-server", config.BinaryPath)
+}

--- a/internal/postalpool/testdata/configs/config.default.yml
+++ b/internal/postalpool/testdata/configs/config.default.yml
@@ -1,0 +1,11 @@
+Enabled: true
+Instances: 2
+StartingPort: 10000
+StartupTimeout: "60s"
+RequestTimeout: "10s"
+Dialer:
+  Timeout: "5s"
+Transport:
+  MaxIdleConnsPerHost: 10
+  MaxIdleConns: 200
+BinaryPath: "/bin/postal-server"


### PR DESCRIPTION
```
goos: darwin
goarch: amd64
pkg: github.com/moov-io/watchman/internal/postalpool
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz

               │ ./internal/postalpool/before.txt │ ./internal/postalpool/after.txt │
               │              sec/op              │    sec/op     vs base           │
_PostalPool-16                       76.08µ ± ∞ ¹   55.66µ ± ∞ ¹  ~ (p=1.000 n=1) ²
Improvement: ~26.8% faster

               │ ./internal/postalpool/before.txt │ ./internal/postalpool/after.txt  │
               │               B/op               │     B/op       vs base           │
_PostalPool-16                      18.75Ki ± ∞ ¹   14.46Ki ± ∞ ¹  ~ (p=1.000 n=1) ²
Improvement: ~22.9% less memory

               │ ./internal/postalpool/before.txt │ ./internal/postalpool/after.txt │
               │            allocs/op             │  allocs/op    vs base           │
_PostalPool-16                        152.0 ± ∞ ¹    143.0 ± ∞ ¹  ~ (p=1.000 n=1) ²
Improvement: ~5.9% fewer allocations
```