### PR TITLE
search: cap groupsize workers by NumCPU / GOMAXPROCS

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -8,6 +8,7 @@ import (
 	watchman "github.com/moov-io/watchman"
 	"github.com/moov-io/watchman/internal/download"
 	"github.com/moov-io/watchman/internal/postalpool"
+	"github.com/moov-io/watchman/internal/search"
 
 	"github.com/moov-io/base/config"
 	"github.com/moov-io/base/log"
@@ -23,6 +24,7 @@ type Config struct {
 	Telemetry telemetry.Config
 
 	Download   download.Config
+	Search     search.Config
 	PostalPool postalpool.Config
 }
 

--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -41,7 +41,8 @@ func TestDownloader_setupPeriodicRefreshing(t *testing.T) {
 	dl, err := download.NewDownloader(logger, conf)
 	require.NoError(t, err)
 
-	searchService, err := search.NewService(logger)
+	searchConfig := search.DefaultConfig()
+	searchService, err := search.NewService(logger, searchConfig)
 	require.NoError(t, err)
 
 	go func() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -69,7 +69,7 @@ func main() {
 	errs := make(chan error, 1)
 
 	// Setup search service and endpoints
-	searchService, err := search.NewService(logger)
+	searchService, err := search.NewService(logger, config.Search)
 	if err != nil {
 		logger.Fatal().LogErrorf("problem setting up search service: %v", err)
 		os.Exit(1)

--- a/configs/config.default.yml
+++ b/configs/config.default.yml
@@ -13,6 +13,14 @@ Watchman:
       - "us_csl"
       - "us_ofac"
 
+  Search:
+    # Tune these settings based on your available resources (CPUs, etc).
+    # Usually a multiple (i.e. 2x, 4x) of GOMAXPROCS is optimal.
+    SearchGroups:
+      Default: 10
+      Min: 1
+      Max: 25
+
   PostalPool:
     Enabled: false
     Instances: 2

--- a/internal/search/api_search_test.go
+++ b/internal/search/api_search_test.go
@@ -45,7 +45,8 @@ func testAPI(tb testing.TB) testSetup {
 
 	logger := log.NewTestLogger()
 
-	service, err := NewService(logger)
+	searchConfig := DefaultConfig()
+	service, err := NewService(logger, searchConfig)
 	require.NoError(tb, err)
 
 	dl := ofactest.GetDownloader(tb)

--- a/internal/search/config.go
+++ b/internal/search/config.go
@@ -1,0 +1,35 @@
+package search
+
+import (
+	"cmp"
+	"os"
+	"runtime"
+	"strconv"
+)
+
+type Config struct {
+	SearchGroups SearchGroups
+}
+
+type SearchGroups struct {
+	Default int
+	Min     int
+	Max     int
+}
+
+func DefaultConfig() Config {
+	cpus := runtime.NumCPU()
+
+	if v := os.Getenv("GOMAXPROCS"); v != "" {
+		n, _ := strconv.ParseInt(v, 10, 8)
+		cpus = cmp.Or(cpus, int(n))
+	}
+
+	return Config{
+		SearchGroups: SearchGroups{
+			Default: cpus * 2,
+			Min:     cpus,
+			Max:     cpus * 4,
+		},
+	}
+}

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -74,7 +74,8 @@ func testService(tb testing.TB) Service {
 
 	logger := log.NewTestLogger()
 
-	svc, err := NewService(logger)
+	searchConfig := DefaultConfig()
+	svc, err := NewService(logger, searchConfig)
 	require.NoError(tb, err)
 
 	svc.UpdateEntities(download.Stats{


### PR DESCRIPTION
With GOMAXPROCS=2

Image: `moov/watchman:dev-b49f05f`

This should result in more stable (less of a long tail) in search performance.

<details>
<summary>Local Benchmarks</summary>

```
                               │  before.txt  │              after.txt               │
                               │    sec/op    │    sec/op     vs base                │
API_Search/normal-2              21.44m ± ∞ ¹   21.18m ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-2               130.3m ± ∞ ¹   136.9m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-2     44.78m ± ∞ ¹   57.62m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/3-2     28.13m ± ∞ ¹   33.17m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/5-2     24.95m ± ∞ ¹   27.29m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/10-2    24.33m ± ∞ ¹   24.17m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/20-2    24.84m ± ∞ ¹   25.93m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/25-2    23.99m ± ∞ ¹   24.24m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/50-2    23.61m ± ∞ ¹   25.08m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-2   25.29m ± ∞ ¹   27.26m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/150-2   28.12m ± ∞ ¹   27.79m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/200-2   27.21m ± ∞ ¹   25.73m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/250-2   23.86m ± ∞ ¹   33.74m ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-2     24.26m ± ∞ ¹   24.42m ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/individual-2     61.18m ± ∞ ¹   59.21m ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/business-2       39.36m ± ∞ ¹   37.76m ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/vessel-2         15.95m ± ∞ ¹   15.61m ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/aircraft-2       15.33m ± ∞ ¹   15.62m ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                          28.90m         30.44m        +5.32%

                               │  before.txt   │               after.txt               │
                               │     B/op      │     B/op       vs base                │
API_Search/normal-2              2.795Mi ± ∞ ¹   2.797Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-2               46.13Mi ± ∞ ¹   46.14Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-2     4.209Mi ± ∞ ¹   4.209Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/3-2     4.209Mi ± ∞ ¹   4.209Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/5-2     4.209Mi ± ∞ ¹   4.209Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/10-2    4.210Mi ± ∞ ¹   4.210Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/20-2    4.211Mi ± ∞ ¹   4.211Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/25-2    4.211Mi ± ∞ ¹   4.211Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/50-2    4.214Mi ± ∞ ¹   4.213Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-2   4.218Mi ± ∞ ¹   4.218Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/150-2   4.223Mi ± ∞ ¹   4.223Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/200-2   4.228Mi ± ∞ ¹   4.227Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/250-2   4.232Mi ± ∞ ¹   4.232Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-2     4.211Mi ± ∞ ¹   4.212Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/individual-2     12.12Mi ± ∞ ¹   12.12Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/business-2       9.003Mi ± ∞ ¹   9.004Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/vessel-2         2.169Mi ± ∞ ¹   2.170Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/aircraft-2       2.102Mi ± ∞ ¹   2.103Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                          4.826Mi         4.827Mi        +0.01%

                               │  before.txt  │              after.txt               │
                               │  allocs/op   │  allocs/op    vs base                │
API_Search/normal-2              189.1k ± ∞ ¹   189.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
API_Search/debug-2               411.0k ± ∞ ¹   411.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/1-2     280.0k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/3-2     280.0k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/5-2     280.0k ± ∞ ¹   280.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/10-2    280.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/20-2    280.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/25-2    280.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/50-2    280.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/100-2   280.2k ± ∞ ¹   280.2k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/fixed_group_size/150-2   280.3k ± ∞ ¹   280.3k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/200-2   280.4k ± ∞ ¹   280.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_Search/fixed_group_size/250-2   280.5k ± ∞ ¹   280.5k ± ∞ ¹       ~ (p=1.000 n=1) ²
_Search/dynamic_group_size-2     280.1k ± ∞ ¹   280.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/individual-2     811.9k ± ∞ ¹   812.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/business-2       456.9k ± ∞ ¹   456.9k ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/vessel-2         183.1k ± ∞ ¹   183.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_SearchParallel/aircraft-2       183.1k ± ∞ ¹   183.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                          291.2k         291.2k        +0.00%
```

</details>