### PR TITLE
search: error requests when extra/unused query params are supplied

### DIFF
--- a/internal/api/url.go
+++ b/internal/api/url.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/url"
+	"slices"
+)
+
+type QueryParams struct {
+	url.Values
+
+	valuesRead []string
+}
+
+func (q *QueryParams) Get(name string) string {
+	q.valuesRead = append(q.valuesRead, name)
+
+	return q.Values.Get(name)
+}
+
+func (q *QueryParams) GetAll(name string) []string {
+	q.Get(name)
+
+	return q.Values[name]
+}
+
+func (q *QueryParams) UnusedQueryParams() []string {
+	var extra []string
+
+	for key := range q.Values {
+		if !slices.Contains(q.valuesRead, key) {
+			extra = append(extra, key)
+		}
+	}
+
+	slices.Sort(extra)
+	return extra
+}

--- a/internal/api/url_test.go
+++ b/internal/api/url_test.go
@@ -1,0 +1,24 @@
+package api_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moov-io/watchman/internal/api"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryParams(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v2/search?name=adam&type=person&addresses=123+first+St", nil)
+
+	qp := api.QueryParams{Values: req.URL.Query()}
+
+	// simulate reading some of the query params
+	qp.Get("name")
+	qp.Get("type")
+
+	// query param provided that we didn't read
+	expected := []string{"addresses"}
+	require.ElementsMatch(t, expected, qp.UnusedQueryParams())
+}

--- a/internal/search/api_search.go
+++ b/internal/search/api_search.go
@@ -67,22 +67,23 @@ func (c *controller) search(w http.ResponseWriter, r *http.Request) {
 	ctx, span := telemetry.StartSpan(r.Context(), "api-search")
 	defer span.End()
 
-	debug := strx.Yes(r.URL.Query().Get("debug"))
+	queryParams := &api.QueryParams{Values: r.URL.Query()}
 
-	req, err := readSearchRequest(ctx, c.addressParsingPool, r)
+	debug := strx.Yes(queryParams.Get("debug"))
+
+	req, err := readSearchRequest(ctx, c.addressParsingPool, queryParams)
 	if err != nil {
 		err = c.logger.Error().LogErrorf("problem reading v2 search request: %w", err).Err()
 		api.ErrorResponse(w, err)
 		return
 	}
 
-	q := r.URL.Query()
 	opts := SearchOpts{
-		Limit:          extractSearchLimit(r),
-		MinMatch:       extractSearchMinMatch(r),
-		RequestID:      q.Get("requestID"),
+		Limit:          extractSearchLimit(queryParams),
+		MinMatch:       extractSearchMinMatch(queryParams),
+		RequestID:      queryParams.Get("requestID"),
 		Debug:          debug,
-		DebugSourceIDs: strings.Split(q.Get("debugSourceIDs"), ","),
+		DebugSourceIDs: strings.Split(queryParams.Get("debugSourceIDs"), ","),
 	}
 
 	span.SetAttributes(
@@ -90,6 +91,14 @@ func (c *controller) search(w http.ResponseWriter, r *http.Request) {
 		attribute.String("entity.type", string(req.Type)),
 	)
 
+	// Check we don't have extra query params
+	if extra := queryParams.UnusedQueryParams(); len(extra) > 0 {
+		err = c.logger.Error().LogErrorf("extra/unused query parameters in request: %v", strings.Join(extra, ",")).Err()
+		api.ErrorResponse(w, err)
+		return
+	}
+
+	// Perform the search
 	entities, err := c.service.Search(ctx, req, opts)
 	if err != nil {
 		err = c.logger.Error().LogErrorf("problem with v2 search: %v", err).Err()
@@ -110,9 +119,9 @@ var (
 	softResultsLimit, hardResultsLimit = 10, 100
 )
 
-func extractSearchLimit(r *http.Request) int {
+func extractSearchLimit(q *api.QueryParams) int {
 	limit := softResultsLimit
-	if v := r.URL.Query().Get("limit"); v != "" {
+	if v := q.Get("limit"); v != "" {
 		n, _ := strconv.Atoi(v)
 		if n > 0 {
 			limit = n
@@ -127,17 +136,15 @@ func extractSearchLimit(r *http.Request) int {
 	return limit
 }
 
-func extractSearchMinMatch(r *http.Request) float64 {
-	if v := r.URL.Query().Get("minMatch"); v != "" {
+func extractSearchMinMatch(q *api.QueryParams) float64 {
+	if v := q.Get("minMatch"); v != "" {
 		n, _ := strconv.ParseFloat(v, 64)
 		return n
 	}
 	return 0.00
 }
 
-func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Service, r *http.Request) (search.Entity[search.Value], error) {
-	q := r.URL.Query()
-
+func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Service, q *api.QueryParams) (search.Entity[search.Value], error) {
 	var err error
 	var req search.Entity[search.Value]
 
@@ -149,18 +156,18 @@ func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Servi
 	case search.EntityPerson:
 		req.Person = &search.Person{
 			Name:      req.Name,
-			AltNames:  q["altNames"],
+			AltNames:  q.GetAll("altNames"),
 			Gender:    search.Gender(prepare.NormalizeGender(q.Get("gender"))),
 			BirthDate: readDate(q.Get("birthDate")),
 			DeathDate: readDate(q.Get("deathDate")),
-			Titles:    q["titles"],
+			Titles:    q.GetAll("titles"),
 			// GovernmentIDs []GovernmentID `json:"governmentIDs"` // TODO(adam):
 		}
 
 	case search.EntityBusiness:
 		req.Business = &search.Business{
 			Name:      req.Name,
-			AltNames:  q["altNames"],
+			AltNames:  q.GetAll("altNames"),
 			Created:   readDate(q.Get("created")),
 			Dissolved: readDate(q.Get("dissolved")),
 			// Identifier []Identifier `json:"identifier"`
@@ -169,7 +176,7 @@ func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Servi
 	case search.EntityOrganization:
 		req.Organization = &search.Organization{
 			Name:      req.Name,
-			AltNames:  q["altNames"],
+			AltNames:  q.GetAll("altNames"),
 			Created:   readDate(q.Get("created")),
 			Dissolved: readDate(q.Get("dissolved")),
 			// Identifier []Identifier `json:"identifier"`
@@ -178,7 +185,7 @@ func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Servi
 	case search.EntityAircraft:
 		req.Aircraft = &search.Aircraft{
 			Name:         req.Name,
-			AltNames:     q["altNames"],
+			AltNames:     q.GetAll("altNames"),
 			Type:         search.AircraftType(q.Get("aircraftType")),
 			Flag:         q.Get("flag"),
 			Built:        readDate("built"),
@@ -190,7 +197,7 @@ func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Servi
 	case search.EntityVessel:
 		req.Vessel = &search.Vessel{
 			Name:      req.Name,
-			AltNames:  q["altNames"],
+			AltNames:  q.GetAll("altNames"),
 			IMONumber: q.Get("imoNumber"),
 			Type:      search.VesselType(q.Get("vesselType")),
 			Flag:      q.Get("flag"),
@@ -219,15 +226,15 @@ func readSearchRequest(ctx context.Context, addressParsingPool *postalpool.Servi
 	}
 
 	// contact info // TODO(adam): normalize
-	req.Contact.EmailAddresses = readStrings(q["email"], q["emailAddress"], q["emailAddresses"])
-	req.Contact.PhoneNumbers = readStrings(q["phone"], q["phoneNumber"], q["phoneNumbers"])
-	req.Contact.FaxNumbers = readStrings(q["fax"], q["faxNumber"], q["faxNumbers"])
-	req.Contact.Websites = readStrings(q["website"], q["websites"])
+	req.Contact.EmailAddresses = readStrings(q.GetAll("email"), q.GetAll("emailAddress"), q.GetAll("emailAddresses"))
+	req.Contact.PhoneNumbers = readStrings(q.GetAll("phone"), q.GetAll("phoneNumber"), q.GetAll("phoneNumbers"))
+	req.Contact.FaxNumbers = readStrings(q.GetAll("fax"), q.GetAll("faxNumber"), q.GetAll("faxNumbers"))
+	req.Contact.Websites = readStrings(q.GetAll("website"), q.GetAll("websites"))
 
-	addresses := readStrings(q["address"], q["addresses"])
+	addresses := readStrings(q.GetAll("address"), q.GetAll("addresses"))
 	req.Addresses = readAddresses(ctx, addressParsingPool, addresses)
 
-	cryptoAddresses := readStrings(q["cryptoAddress"], q["cryptoAddresses"])
+	cryptoAddresses := readStrings(q.GetAll("cryptoAddress"), q.GetAll("cryptoAddresses"))
 	req.CryptoAddresses = readCryptoCurrencyAddresses(cryptoAddresses)
 
 	// TODO(adam):

--- a/internal/search/api_search_test.go
+++ b/internal/search/api_search_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/api"
 	"github.com/moov-io/watchman/internal/ofactest"
 	"github.com/moov-io/watchman/pkg/search"
 
@@ -73,8 +74,9 @@ func TestAPI_readSearchRequest(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/v2/search?name=adam&type=person&birthDate=2025-01-02", nil)
+		q := &api.QueryParams{Values: req.URL.Query()}
 
-		query, err := readSearchRequest(ctx, nil, req)
+		query, err := readSearchRequest(ctx, nil, q)
 		require.NoError(t, err)
 
 		require.Equal(t, "adam", query.Name)
@@ -91,8 +93,9 @@ func TestAPI_readSearchRequest(t *testing.T) {
 		address += "&website=corp.com&website=corp2.com"
 
 		req := httptest.NewRequest("GET", address, nil)
+		q := &api.QueryParams{Values: req.URL.Query()}
 
-		query, err := readSearchRequest(ctx, nil, req)
+		query, err := readSearchRequest(ctx, nil, q)
 		require.NoError(t, err)
 		require.Empty(t, query.Name)
 
@@ -110,8 +113,9 @@ func TestAPI_readSearchRequest(t *testing.T) {
 
 	t.Run("crypto addresses", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/v2/search?type=person&cryptoAddress=xbt:12345&cryptoAddress=eth:54321", nil)
+		q := &api.QueryParams{Values: req.URL.Query()}
 
-		query, err := readSearchRequest(ctx, nil, req)
+		query, err := readSearchRequest(ctx, nil, q)
 		require.NoError(t, err)
 		require.Empty(t, query.Name)
 
@@ -126,7 +130,9 @@ func TestAPI_readSearchRequest(t *testing.T) {
 
 	t.Run("address", func(t *testing.T) {
 		req := httptest.NewRequest("GET", "/v2/search?type=person&name=Jane&address=123+Acme+St+Acmetown+KY+54321+US", nil)
-		query, err := readSearchRequest(ctx, nil, req)
+		q := &api.QueryParams{Values: req.URL.Query()}
+
+		query, err := readSearchRequest(ctx, nil, q)
 		require.NoError(t, err)
 
 		require.Equal(t, "Jane", query.Name)
@@ -152,6 +158,8 @@ func TestAPI_Search(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		env.router.ServeHTTP(w, req)
+
+		t.Log(w.Body.String())
 
 		require.Equal(t, http.StatusOK, w.Code)
 


### PR DESCRIPTION
This can often be from typos in the request which are hard to debug.