### PR TITLE
search: compare entity type (when populated)

### DIFF
--- a/internal/search/api_search_test.go
+++ b/internal/search/api_search_test.go
@@ -90,6 +90,17 @@ func TestAPI_readSearchRequest(t *testing.T) {
 
 	})
 
+	t.Run("name without type", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/v2/search?name=adam", nil)
+		q := &api.QueryParams{Values: req.URL.Query()}
+
+		query, err := readSearchRequest(ctx, nil, q)
+		require.NoError(t, err)
+
+		require.Equal(t, "adam", query.Name)
+		require.Empty(t, query.Type)
+	})
+
 	t.Run("contact info", func(t *testing.T) {
 		address := "/v2/search?type=business&emailAddress=a@corp.com&phone=1234567890"
 		address += "&faxNumber=3334445566&email=b@corp.com&phone=9876543210"

--- a/pkg/search/similarity.go
+++ b/pkg/search/similarity.go
@@ -60,7 +60,8 @@ func DebugSimilarity[Q any, I any](w io.Writer, query Entity[Q], index Entity[I]
 }
 
 var (
-	emptyPieces = make([]ScorePiece, 9)
+	emptyPieces     = make([]ScorePiece, 9)
+	emptyEntityType = EntityType("")
 )
 
 // DetailedSimilarity returns the scoring details of each query piece against the index Entity.
@@ -73,15 +74,21 @@ func DetailedSimilarity[Q any, I any](w io.Writer, query Entity[Q], index Entity
 		Pieces: make([]ScorePiece, 0, 9),
 	}
 
+	// Quick filters
 	if query.Source != sourceEmpty && query.Source != SourceAPIRequest {
 		if query.Source != index.Source {
 			out.Pieces = emptyPieces
 			return out
 		}
 	}
-
 	if query.SourceID != "" {
 		if query.SourceID != index.SourceID {
+			out.Pieces = emptyPieces
+			return out
+		}
+	}
+	if query.Type != emptyEntityType {
+		if query.Type != index.Type {
 			out.Pieces = emptyPieces
 			return out
 		}

--- a/pkg/search/similarity_ofac_test.go
+++ b/pkg/search/similarity_ofac_test.go
@@ -102,10 +102,17 @@ func TestSimilarity_OFAC_SDN_Person(t *testing.T) {
 			expected: 0.155,
 		},
 		{
-			name: "missing entity type",
+			name: "mismatched entity type",
 			query: search.Entity[any]{
 				Name: "JOHN SMITH",
 				Type: search.EntityVessel, // intentionally vessel to mismatch
+			},
+			expected: 0.0,
+		},
+		{
+			name: "missing entity type",
+			query: search.Entity[any]{
+				Name: "JOHN SMITH",
 			},
 			expected: 0.1396,
 		},
@@ -201,10 +208,17 @@ func TestSimilarity_OFAC_SDN_Business(t *testing.T) {
 			expected: 0.087,
 		},
 		{
-			name: "missing entity type",
+			name: "mismatched entity type",
 			query: search.Entity[any]{
 				Name: "ACME Corporation",
 				Type: search.EntityVessel,
+			},
+			expected: 0.0,
+		},
+		{
+			name: "missing entity type",
+			query: search.Entity[any]{
+				Name: "ACME Corporation",
 			},
 			expected: 0.2761,
 		},
@@ -361,6 +375,13 @@ func TestSimilarity_Edge_Cases(t *testing.T) {
 			query: search.Entity[any]{
 				Name: "TEST ENTITY",
 				Type: search.EntityBusiness,
+			},
+			expected: 0.0,
+		},
+		{
+			name: "Missing entity type",
+			query: search.Entity[any]{
+				Name: "TEST ENTITY",
 			},
 			expected: 0.855,
 		},


### PR DESCRIPTION
Reported in slack this was broken - https://moov-io.slack.com/archives/CFUCEBGH2/p1750756426453359?thread_ts=1748893417.298209&cid=CFUCEBGH2 