### PR TITLE
Fix curl command URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run -p 8084:8084 moov/watchman:latest
 
 Run a search for an individual or business:
 ```
-curl -s "http://localhost:8084/v2/search?name=Nicolas+Maduro&type=person&limit=1&minMatch=0.75" | jq .
+curl -s "http://localhost:8084/search?name=Nicolas+Maduro&type=person&limit=1&minMatch=0.75" | jq .
 ```
 
 <details>


### PR DESCRIPTION
Using the latest version of Moov Watchman, you'll get a `404 page not found` error if you hit `http://localhost:8084/v2/search`. The correct URL does _not_ have a `v2` namespace: it's `http://localhost:8084/search`.