### PR TITLE
feat: add geocoding support for address latitude/longitude (#622)

### DIFF
--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -42,7 +42,7 @@ func TestDownloader_setupPeriodicRefreshing(t *testing.T) {
 		InitialDataDirectory: filepath.Join(pkg, "ofac", "testdata"),
 	}
 
-	dl, err := download.NewDownloader(logger, conf)
+	dl, err := download.NewDownloader(logger, conf, nil)
 	require.NoError(t, err)
 
 	indexedLists := index.NewLists(nil) // only in-memory

--- a/configs/config.default.yml
+++ b/configs/config.default.yml
@@ -33,3 +33,18 @@ Watchman:
     RequestTimeout: "10s"
     BinaryPath: "" # POSTAL_SERVER_BIN_PATH is set in Dockerfile
     CGOSelfInstances: 1
+
+  Geocoding:
+    Enabled: false
+    Provider:
+      Name: "opencage"    # opencage, google, or nominatim
+      APIKey: ""          # Can be set via GEOCODING_API_KEY env var
+      BaseURL: ""         # Optional: override for self-hosted Nominatim
+      Timeout: "10s"
+    RateLimit:
+      RequestsPerSecond: 1  # Free tier: 1/sec, Paid: up to 40/sec
+      Burst: 5
+    Cache:
+      L1MaxSize: 10000      # In-memory LRU cache size
+      L1TTL: "24h"          # TTL for L1 cache entries
+      L2Enabled: true       # Persist to database (requires Database config)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	watchman "github.com/moov-io/watchman"
 	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/internal/geocoding"
 	"github.com/moov-io/watchman/internal/ingest"
 	"github.com/moov-io/watchman/internal/postalpool"
 	"github.com/moov-io/watchman/internal/search"
@@ -33,6 +34,7 @@ type Config struct {
 	Download   download.Config
 	Search     search.Config
 	PostalPool postalpool.Config
+	Geocoding  geocoding.Config
 
 	Ingest ingest.Config
 }

--- a/internal/cslustest/cslustest.go
+++ b/internal/cslustest/cslustest.go
@@ -33,7 +33,7 @@ func FindEntity(tb testing.TB, entityID string) search.Entity[search.Value] {
 		}
 		conf.IncludedLists = append(conf.IncludedLists, search.SourceUSCSL)
 
-		dl, err := download.NewDownloader(logger, conf)
+		dl, err := download.NewDownloader(logger, conf, nil)
 		require.NoError(tb, err)
 
 		cslusDownloader = dl

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -22,7 +22,7 @@ func TestDownloader_RefreshAll_InitialDir(t *testing.T) {
 		},
 	}
 
-	dl, err := download.NewDownloader(logger, conf)
+	dl, err := download.NewDownloader(logger, conf, nil)
 	require.NoError(t, err)
 	require.NotNil(t, dl)
 

--- a/internal/geocoding/config.go
+++ b/internal/geocoding/config.go
@@ -1,0 +1,80 @@
+package geocoding
+
+import "time"
+
+// Config holds the configuration for the geocoding service.
+type Config struct {
+	// Enabled controls whether geocoding is active.
+	Enabled bool
+
+	// Provider configuration for the geocoding API.
+	Provider ProviderConfig
+
+	// RateLimit configuration to control API request rates.
+	RateLimit RateLimitConfig
+
+	// Cache configuration for L1 (in-memory) and L2 (database) caching.
+	Cache CacheConfig
+}
+
+// ProviderConfig holds settings for a geocoding provider.
+type ProviderConfig struct {
+	// Name of the provider: "opencage", "google", or "nominatim"
+	Name string
+
+	// APIKey for authentication with the provider.
+	// Can be set via GEOCODING_API_KEY environment variable.
+	APIKey string
+
+	// BaseURL allows overriding the default API endpoint.
+	// Useful for self-hosted Nominatim instances.
+	BaseURL string
+
+	// Timeout for API requests. Default: 10s
+	Timeout time.Duration
+}
+
+// RateLimitConfig controls the rate of geocoding API requests.
+type RateLimitConfig struct {
+	// RequestsPerSecond defines the sustained request rate.
+	// Free tier typically allows 1/sec, paid tiers allow up to 40/sec.
+	RequestsPerSecond float64
+
+	// Burst allows temporary exceeding of the rate limit.
+	Burst int
+}
+
+// CacheConfig controls caching behavior for geocoding results.
+type CacheConfig struct {
+	// L1MaxSize is the maximum number of entries in the in-memory LRU cache.
+	// Default: 10000
+	L1MaxSize int
+
+	// L1TTL is the time-to-live for L1 cache entries.
+	// Default: 24h
+	L1TTL time.Duration
+
+	// L2Enabled enables the database-backed persistent cache.
+	// Requires a database connection.
+	L2Enabled bool
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		Enabled: false,
+		Provider: ProviderConfig{
+			Name:    "opencage",
+			Timeout: 10 * time.Second,
+		},
+		RateLimit: RateLimitConfig{
+			RequestsPerSecond: 1,
+			Burst:             5,
+		},
+		Cache: CacheConfig{
+			L1MaxSize: 10000,
+			L1TTL:     24 * time.Hour,
+			L2Enabled: true,
+		},
+	}
+}

--- a/internal/geocoding/geocoder.go
+++ b/internal/geocoding/geocoder.go
@@ -1,0 +1,37 @@
+package geocoding
+
+import (
+	"context"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// Coordinates represents geographic coordinates returned by a geocoding provider.
+type Coordinates struct {
+	Latitude  float64
+	Longitude float64
+	// Accuracy indicates the precision level of the geocoding result.
+	// Possible values: "rooftop", "street", "city", "state", "country", "approximate"
+	Accuracy string
+}
+
+// Geocoder is the interface that geocoding providers must implement.
+type Geocoder interface {
+	// Geocode converts an address to geographic coordinates.
+	// Returns nil coordinates if the address cannot be geocoded.
+	Geocode(ctx context.Context, address search.Address) (*Coordinates, error)
+
+	// Name returns the provider name for logging and metrics.
+	Name() string
+}
+
+// NoOpGeocoder is a geocoder that does nothing, used when geocoding is disabled.
+type NoOpGeocoder struct{}
+
+func (n *NoOpGeocoder) Geocode(ctx context.Context, address search.Address) (*Coordinates, error) {
+	return nil, nil
+}
+
+func (n *NoOpGeocoder) Name() string {
+	return "noop"
+}

--- a/internal/geocoding/google.go
+++ b/internal/geocoding/google.go
@@ -1,0 +1,135 @@
+package geocoding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+const googleBaseURL = "https://maps.googleapis.com/maps/api/geocode/json"
+
+// GoogleGeocoder implements the Geocoder interface using the Google Maps API.
+type GoogleGeocoder struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+type googleResponse struct {
+	Results      []googleResult `json:"results"`
+	Status       string         `json:"status"`
+	ErrorMessage string         `json:"error_message"`
+}
+
+type googleResult struct {
+	Geometry struct {
+		Location struct {
+			Lat float64 `json:"lat"`
+			Lng float64 `json:"lng"`
+		} `json:"location"`
+		LocationType string `json:"location_type"`
+	} `json:"geometry"`
+}
+
+// NewGoogleGeocoder creates a new Google Maps geocoder.
+func NewGoogleGeocoder(conf ProviderConfig) (*GoogleGeocoder, error) {
+	if conf.APIKey == "" {
+		return nil, fmt.Errorf("Google Maps API key is required")
+	}
+
+	baseURL := conf.BaseURL
+	if baseURL == "" {
+		baseURL = googleBaseURL
+	}
+
+	timeout := conf.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	return &GoogleGeocoder{
+		apiKey:  conf.APIKey,
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+// Geocode converts an address to coordinates using the Google Maps API.
+func (g *GoogleGeocoder) Geocode(ctx context.Context, addr search.Address) (*Coordinates, error) {
+	query := addr.Format()
+	if query == "" {
+		return nil, nil
+	}
+
+	reqURL := fmt.Sprintf("%s?key=%s&address=%s",
+		g.baseURL,
+		url.QueryEscape(g.apiKey),
+		url.QueryEscape(query),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result googleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	switch result.Status {
+	case "OK":
+		// Success, continue processing
+	case "ZERO_RESULTS":
+		return nil, nil // No results found
+	case "OVER_QUERY_LIMIT", "REQUEST_DENIED", "INVALID_REQUEST", "UNKNOWN_ERROR":
+		return nil, fmt.Errorf("google geocoding error: %s - %s", result.Status, result.ErrorMessage)
+	default:
+		return nil, fmt.Errorf("google geocoding unexpected status: %s", result.Status)
+	}
+
+	if len(result.Results) == 0 {
+		return nil, nil
+	}
+
+	r := result.Results[0]
+	return &Coordinates{
+		Latitude:  r.Geometry.Location.Lat,
+		Longitude: r.Geometry.Location.Lng,
+		Accuracy:  googleLocationTypeToAccuracy(r.Geometry.LocationType),
+	}, nil
+}
+
+// Name returns the provider name.
+func (g *GoogleGeocoder) Name() string {
+	return "google"
+}
+
+// googleLocationTypeToAccuracy converts Google location type to accuracy string.
+func googleLocationTypeToAccuracy(locationType string) string {
+	switch locationType {
+	case "ROOFTOP":
+		return "rooftop"
+	case "RANGE_INTERPOLATED":
+		return "street"
+	case "GEOMETRIC_CENTER":
+		return "city"
+	case "APPROXIMATE":
+		return "approximate"
+	default:
+		return "approximate"
+	}
+}

--- a/internal/geocoding/integration_test.go
+++ b/internal/geocoding/integration_test.go
@@ -1,0 +1,206 @@
+// +build integration
+
+package geocoding
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/stretchr/testify/require"
+)
+
+// Integration tests for geocoding providers.
+// These tests require real API keys and make actual network requests.
+//
+// Run with: go test -tags=integration -v ./internal/geocoding/...
+//
+// Required environment variables:
+//   OPENCAGE_API_KEY - OpenCage API key (get free key at https://opencagedata.com)
+//   GOOGLE_API_KEY   - Google Maps API key (optional)
+//
+// Note: These tests are rate-limited and should not be run frequently.
+
+func TestIntegration_OpenCage_RealAPI(t *testing.T) {
+	apiKey := os.Getenv("OPENCAGE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCAGE_API_KEY not set, skipping integration test")
+	}
+
+	geocoder, err := NewOpenCageGeocoder(ProviderConfig{
+		APIKey:  apiKey,
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Test with a well-known address
+	addr := search.Address{
+		Line1:   "1600 Amphitheatre Parkway",
+		City:    "Mountain View",
+		State:   "CA",
+		Country: "US",
+	}
+
+	coords, err := geocoder.Geocode(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords, "expected coordinates for Google HQ address")
+
+	// Google HQ is approximately at 37.4220, -122.0841
+	require.InDelta(t, 37.42, coords.Latitude, 0.01, "latitude should be close to 37.42")
+	require.InDelta(t, -122.08, coords.Longitude, 0.01, "longitude should be close to -122.08")
+
+	t.Logf("OpenCage returned: lat=%.6f, lng=%.6f, accuracy=%s",
+		coords.Latitude, coords.Longitude, coords.Accuracy)
+}
+
+func TestIntegration_OpenCage_UnknownAddress(t *testing.T) {
+	apiKey := os.Getenv("OPENCAGE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCAGE_API_KEY not set, skipping integration test")
+	}
+
+	geocoder, err := NewOpenCageGeocoder(ProviderConfig{
+		APIKey:  apiKey,
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Test with a nonsense address
+	addr := search.Address{
+		Line1:   "xyzzy123456 nonexistent street",
+		City:    "Nowhere City",
+		Country: "XX",
+	}
+
+	coords, err := geocoder.Geocode(context.Background(), addr)
+	require.NoError(t, err)
+	// Should return nil or very low confidence result
+	t.Logf("OpenCage returned for unknown address: %+v", coords)
+}
+
+func TestIntegration_Nominatim_RealAPI(t *testing.T) {
+	// Nominatim doesn't require API key but has strict rate limits
+	// Be respectful: max 1 request per second for public API
+
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Test with a well-known address
+	addr := search.Address{
+		Line1:   "Empire State Building",
+		City:    "New York",
+		State:   "NY",
+		Country: "US",
+	}
+
+	coords, err := geocoder.Geocode(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords, "expected coordinates for Empire State Building")
+
+	// Empire State Building is approximately at 40.7484, -73.9857
+	require.InDelta(t, 40.75, coords.Latitude, 0.01, "latitude should be close to 40.75")
+	require.InDelta(t, -73.99, coords.Longitude, 0.01, "longitude should be close to -73.99")
+
+	t.Logf("Nominatim returned: lat=%.6f, lng=%.6f, accuracy=%s",
+		coords.Latitude, coords.Longitude, coords.Accuracy)
+}
+
+func TestIntegration_Google_RealAPI(t *testing.T) {
+	apiKey := os.Getenv("GOOGLE_API_KEY")
+	if apiKey == "" {
+		t.Skip("GOOGLE_API_KEY not set, skipping integration test")
+	}
+
+	geocoder, err := NewGoogleGeocoder(ProviderConfig{
+		APIKey:  apiKey,
+		Timeout: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Test with a well-known address
+	addr := search.Address{
+		Line1:   "Statue of Liberty",
+		City:    "New York",
+		State:   "NY",
+		Country: "US",
+	}
+
+	coords, err := geocoder.Geocode(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords, "expected coordinates for Statue of Liberty")
+
+	// Statue of Liberty is approximately at 40.6892, -74.0445
+	require.InDelta(t, 40.69, coords.Latitude, 0.01, "latitude should be close to 40.69")
+	require.InDelta(t, -74.04, coords.Longitude, 0.01, "longitude should be close to -74.04")
+
+	t.Logf("Google returned: lat=%.6f, lng=%.6f, accuracy=%s",
+		coords.Latitude, coords.Longitude, coords.Accuracy)
+}
+
+func TestIntegration_FullService_WithCaching(t *testing.T) {
+	apiKey := os.Getenv("OPENCAGE_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENCAGE_API_KEY not set, skipping integration test")
+	}
+
+	conf := Config{
+		Enabled: true,
+		Provider: ProviderConfig{
+			Name:    "opencage",
+			APIKey:  apiKey,
+			Timeout: 30 * time.Second,
+		},
+		RateLimit: RateLimitConfig{
+			RequestsPerSecond: 1, // Free tier limit
+			Burst:             1,
+		},
+		Cache: CacheConfig{
+			L1MaxSize: 100,
+			L1TTL:     time.Hour,
+			L2Enabled: false, // No database in this test
+		},
+	}
+
+	svc, err := NewService(log.NewTestLogger(), conf, nil)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	addr := search.Address{
+		Line1:   "10 Downing Street",
+		City:    "London",
+		Country: "UK",
+	}
+
+	// First call - should hit the API
+	start := time.Now()
+	coords1, err := svc.GeocodeAddress(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords1)
+	apiDuration := time.Since(start)
+
+	t.Logf("First call (API): lat=%.6f, lng=%.6f, took=%v",
+		coords1.Latitude, coords1.Longitude, apiDuration)
+
+	// Second call - should hit L1 cache (much faster)
+	start = time.Now()
+	coords2, err := svc.GeocodeAddress(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords2)
+	cacheDuration := time.Since(start)
+
+	t.Logf("Second call (cache): lat=%.6f, lng=%.6f, took=%v",
+		coords2.Latitude, coords2.Longitude, cacheDuration)
+
+	// Cache should be significantly faster
+	require.Less(t, cacheDuration, apiDuration/10,
+		"cached call should be at least 10x faster than API call")
+
+	// Results should be identical
+	require.Equal(t, coords1.Latitude, coords2.Latitude)
+	require.Equal(t, coords1.Longitude, coords2.Longitude)
+}

--- a/internal/geocoding/nominatim.go
+++ b/internal/geocoding/nominatim.go
@@ -1,0 +1,144 @@
+package geocoding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+const nominatimBaseURL = "https://nominatim.openstreetmap.org/search"
+
+// NominatimGeocoder implements the Geocoder interface using OpenStreetMap's Nominatim API.
+// Note: The public Nominatim server has strict usage policies (max 1 request/second).
+// For production use, consider hosting your own Nominatim instance.
+type NominatimGeocoder struct {
+	baseURL string
+	client  *http.Client
+}
+
+type nominatimResult struct {
+	Lat         string  `json:"lat"`
+	Lon         string  `json:"lon"`
+	DisplayName string  `json:"display_name"`
+	Class       string  `json:"class"`
+	Type        string  `json:"type"`
+	Importance  float64 `json:"importance"`
+}
+
+// NewNominatimGeocoder creates a new Nominatim geocoder.
+// APIKey is not required for Nominatim (it's free and open).
+func NewNominatimGeocoder(conf ProviderConfig) (*NominatimGeocoder, error) {
+	baseURL := conf.BaseURL
+	if baseURL == "" {
+		baseURL = nominatimBaseURL
+	}
+
+	timeout := conf.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	return &NominatimGeocoder{
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+// Geocode converts an address to coordinates using the Nominatim API.
+func (g *NominatimGeocoder) Geocode(ctx context.Context, addr search.Address) (*Coordinates, error) {
+	query := addr.Format()
+	if query == "" {
+		return nil, nil
+	}
+
+	reqURL := fmt.Sprintf("%s?format=json&q=%s&limit=1",
+		g.baseURL,
+		url.QueryEscape(query),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Nominatim requires a descriptive User-Agent
+	req.Header.Set("User-Agent", "moov-io/watchman (https://github.com/moov-io/watchman)")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("nominatim returned status %d", resp.StatusCode)
+	}
+
+	var results []nominatimResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if len(results) == 0 {
+		return nil, nil // No results found
+	}
+
+	r := results[0]
+	lat, err := strconv.ParseFloat(r.Lat, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing latitude: %w", err)
+	}
+
+	lon, err := strconv.ParseFloat(r.Lon, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parsing longitude: %w", err)
+	}
+
+	return &Coordinates{
+		Latitude:  lat,
+		Longitude: lon,
+		Accuracy:  nominatimClassToAccuracy(r.Class, r.Type),
+	}, nil
+}
+
+// Name returns the provider name.
+func (g *NominatimGeocoder) Name() string {
+	return "nominatim"
+}
+
+// nominatimClassToAccuracy converts Nominatim class/type to accuracy string.
+func nominatimClassToAccuracy(class, typ string) string {
+	switch class {
+	case "building":
+		return "rooftop"
+	case "place":
+		switch typ {
+		case "house", "building":
+			return "rooftop"
+		case "street", "road":
+			return "street"
+		case "city", "town", "village", "hamlet":
+			return "city"
+		case "state", "province", "region":
+			return "state"
+		case "country":
+			return "country"
+		}
+	case "highway":
+		return "street"
+	case "boundary":
+		switch typ {
+		case "administrative":
+			return "city"
+		}
+	}
+	return "approximate"
+}

--- a/internal/geocoding/nominatim_test.go
+++ b/internal/geocoding/nominatim_test.go
@@ -1,0 +1,139 @@
+package geocoding
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNominatimGeocoder_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, r.URL.RawQuery, "format=json")
+		require.Contains(t, r.URL.RawQuery, "q=")
+		require.Contains(t, r.URL.RawQuery, "limit=1")
+
+		// Check User-Agent header
+		userAgent := r.Header.Get("User-Agent")
+		require.Contains(t, userAgent, "moov-io/watchman")
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{
+			"lat": "40.7128",
+			"lon": "-74.0060",
+			"display_name": "123 Main St, New York, NY, USA",
+			"class": "building",
+			"type": "house",
+			"importance": 0.9
+		}]`))
+	}))
+	defer server.Close()
+
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	addr := search.Address{
+		Line1:   "123 Main St",
+		City:    "New York",
+		State:   "NY",
+		Country: "US",
+	}
+
+	coords, err := geocoder.Geocode(context.Background(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, coords)
+	require.Equal(t, 40.7128, coords.Latitude)
+	require.Equal(t, -74.0060, coords.Longitude)
+	require.Equal(t, "rooftop", coords.Accuracy)
+}
+
+func TestNominatimGeocoder_NoResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	coords, err := geocoder.Geocode(context.Background(), search.Address{Line1: "unknown"})
+	require.NoError(t, err)
+	require.Nil(t, coords)
+}
+
+func TestNominatimGeocoder_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{
+		BaseURL: server.URL,
+	})
+	require.NoError(t, err)
+
+	coords, err := geocoder.Geocode(context.Background(), search.Address{Line1: "test"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 429")
+	require.Nil(t, coords)
+}
+
+func TestNominatimGeocoder_EmptyAddress(t *testing.T) {
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{})
+	require.NoError(t, err)
+
+	coords, err := geocoder.Geocode(context.Background(), search.Address{})
+	require.NoError(t, err)
+	require.Nil(t, coords)
+}
+
+func TestNominatimGeocoder_Name(t *testing.T) {
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{})
+	require.NoError(t, err)
+	require.Equal(t, "nominatim", geocoder.Name())
+}
+
+func TestNominatimClassToAccuracy(t *testing.T) {
+	tests := []struct {
+		class    string
+		typ      string
+		expected string
+	}{
+		{"building", "", "rooftop"},
+		{"place", "house", "rooftop"},
+		{"place", "building", "rooftop"},
+		{"place", "street", "street"},
+		{"place", "road", "street"},
+		{"place", "city", "city"},
+		{"place", "town", "city"},
+		{"place", "village", "city"},
+		{"place", "state", "state"},
+		{"place", "country", "country"},
+		{"highway", "", "street"},
+		{"boundary", "administrative", "city"},
+		{"boundary", "other", "approximate"},
+		{"unknown", "", "approximate"},
+		{"", "", "approximate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.class+"/"+tt.typ, func(t *testing.T) {
+			require.Equal(t, tt.expected, nominatimClassToAccuracy(tt.class, tt.typ))
+		})
+	}
+}
+
+func TestNominatimGeocoder_NoAPIKeyRequired(t *testing.T) {
+	// Nominatim doesn't require an API key
+	geocoder, err := NewNominatimGeocoder(ProviderConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, geocoder)
+}

--- a/internal/geocoding/opencage.go
+++ b/internal/geocoding/opencage.go
@@ -1,0 +1,137 @@
+package geocoding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+const openCageBaseURL = "https://api.opencagedata.com/geocode/v1/json"
+
+// OpenCageGeocoder implements the Geocoder interface using the OpenCage API.
+type OpenCageGeocoder struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+type openCageResponse struct {
+	Results []openCageResult `json:"results"`
+	Status  openCageStatus   `json:"status"`
+}
+
+type openCageResult struct {
+	Geometry struct {
+		Lat float64 `json:"lat"`
+		Lng float64 `json:"lng"`
+	} `json:"geometry"`
+	Confidence int `json:"confidence"`
+}
+
+type openCageStatus struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// NewOpenCageGeocoder creates a new OpenCage geocoder.
+func NewOpenCageGeocoder(conf ProviderConfig) (*OpenCageGeocoder, error) {
+	if conf.APIKey == "" {
+		return nil, fmt.Errorf("OpenCage API key is required")
+	}
+
+	baseURL := conf.BaseURL
+	if baseURL == "" {
+		baseURL = openCageBaseURL
+	}
+
+	timeout := conf.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	return &OpenCageGeocoder{
+		apiKey:  conf.APIKey,
+		baseURL: baseURL,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+// Geocode converts an address to coordinates using the OpenCage API.
+func (g *OpenCageGeocoder) Geocode(ctx context.Context, addr search.Address) (*Coordinates, error) {
+	query := addr.Format()
+	if query == "" {
+		return nil, nil
+	}
+
+	reqURL := fmt.Sprintf("%s?key=%s&q=%s&no_annotations=1&limit=1",
+		g.baseURL,
+		url.QueryEscape(g.apiKey),
+		url.QueryEscape(query),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "moov-io/watchman")
+
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("opencage returned status %d", resp.StatusCode)
+	}
+
+	var result openCageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	if result.Status.Code != 200 {
+		return nil, fmt.Errorf("opencage error: %s (code %d)", result.Status.Message, result.Status.Code)
+	}
+
+	if len(result.Results) == 0 {
+		return nil, nil // No results found
+	}
+
+	r := result.Results[0]
+	return &Coordinates{
+		Latitude:  r.Geometry.Lat,
+		Longitude: r.Geometry.Lng,
+		Accuracy:  confidenceToAccuracy(r.Confidence),
+	}, nil
+}
+
+// Name returns the provider name.
+func (g *OpenCageGeocoder) Name() string {
+	return "opencage"
+}
+
+// confidenceToAccuracy converts OpenCage confidence level to accuracy string.
+// Confidence ranges from 1 (low) to 10 (high).
+func confidenceToAccuracy(confidence int) string {
+	switch {
+	case confidence >= 9:
+		return "rooftop"
+	case confidence >= 7:
+		return "street"
+	case confidence >= 5:
+		return "city"
+	case confidence >= 3:
+		return "state"
+	default:
+		return "country"
+	}
+}

--- a/internal/geocoding/repository.go
+++ b/internal/geocoding/repository.go
@@ -1,0 +1,79 @@
+package geocoding
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/moov-io/watchman/internal/db"
+)
+
+// Repository defines the interface for the L2 (database) cache.
+type Repository interface {
+	// Get retrieves coordinates from the cache by key.
+	// Returns nil if not found.
+	Get(ctx context.Context, cacheKey string) (*Coordinates, error)
+
+	// Set stores coordinates in the cache.
+	Set(ctx context.Context, cacheKey string, coords *Coordinates) error
+}
+
+type sqlRepository struct {
+	db db.DB
+}
+
+// NewRepository creates a new database repository for geocoding cache.
+func NewRepository(database db.DB) Repository {
+	if database == nil {
+		return nil
+	}
+	return &sqlRepository{db: database}
+}
+
+// Get retrieves coordinates from the database cache.
+func (r *sqlRepository) Get(ctx context.Context, cacheKey string) (*Coordinates, error) {
+	query := `SELECT latitude, longitude, accuracy FROM geocoding_cache WHERE cache_key = ? LIMIT 1`
+
+	var coords Coordinates
+	row := r.db.QueryRowContext(ctx, query, cacheKey)
+	err := row.Scan(&coords.Latitude, &coords.Longitude, &coords.Accuracy)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying geocoding cache: %w", err)
+	}
+
+	return &coords, nil
+}
+
+// Set stores coordinates in the database cache.
+// Uses upsert to handle duplicate keys.
+func (r *sqlRepository) Set(ctx context.Context, cacheKey string, coords *Coordinates) error {
+	// Use INSERT ... ON CONFLICT for PostgreSQL compatibility
+	// The db wrapper will handle rebinding for MySQL
+	query := `
+		INSERT INTO geocoding_cache (cache_key, latitude, longitude, accuracy, created_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (cache_key) DO UPDATE SET
+			latitude = EXCLUDED.latitude,
+			longitude = EXCLUDED.longitude,
+			accuracy = EXCLUDED.accuracy,
+			created_at = EXCLUDED.created_at
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		cacheKey,
+		coords.Latitude,
+		coords.Longitude,
+		coords.Accuracy,
+		time.Now().UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("inserting into geocoding cache: %w", err)
+	}
+
+	return nil
+}

--- a/internal/geocoding/service.go
+++ b/internal/geocoding/service.go
@@ -1,0 +1,230 @@
+package geocoding
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/telemetry"
+	"github.com/moov-io/watchman/internal/db"
+	"github.com/moov-io/watchman/pkg/search"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/time/rate"
+)
+
+// Service provides geocoding with caching and rate limiting.
+// It manages L1 (in-memory) and L2 (database) caches and applies
+// rate limiting to external API calls.
+type Service struct {
+	logger   log.Logger
+	conf     Config
+	geocoder Geocoder
+	limiter  *rate.Limiter
+
+	// L1 cache (in-memory LRU with TTL)
+	l1Cache *lru.Cache[string, cacheEntry]
+	l1TTL   time.Duration
+	mu      sync.RWMutex
+
+	// L2 cache (database)
+	l2Repo Repository
+}
+
+type cacheEntry struct {
+	coords    *Coordinates
+	timestamp time.Time
+}
+
+// NewService creates a new geocoding service with the provided configuration.
+// Returns nil if geocoding is disabled.
+func NewService(logger log.Logger, conf Config, database db.DB) (*Service, error) {
+	if !conf.Enabled {
+		logger.Info().Log("geocoding service is disabled")
+		return nil, nil
+	}
+
+	// Create geocoder based on provider config
+	geocoder, err := createGeocoder(conf.Provider)
+	if err != nil {
+		return nil, fmt.Errorf("creating geocoder: %w", err)
+	}
+
+	// Create rate limiter
+	limiter := rate.NewLimiter(
+		rate.Limit(conf.RateLimit.RequestsPerSecond),
+		conf.RateLimit.Burst,
+	)
+
+	// Set defaults if not configured
+	l1MaxSize := conf.Cache.L1MaxSize
+	if l1MaxSize <= 0 {
+		l1MaxSize = 10000
+	}
+
+	l1TTL := conf.Cache.L1TTL
+	if l1TTL <= 0 {
+		l1TTL = 24 * time.Hour
+	}
+
+	// Create L1 cache
+	l1Cache, err := lru.New[string, cacheEntry](l1MaxSize)
+	if err != nil {
+		return nil, fmt.Errorf("creating L1 cache: %w", err)
+	}
+
+	// Create L2 repository if enabled and database available
+	var l2Repo Repository
+	if conf.Cache.L2Enabled && database != nil {
+		l2Repo = NewRepository(database)
+	}
+
+	logger.Info().Logf("geocoding service enabled with provider=%s, rateLimit=%.1f/sec, l1CacheSize=%d",
+		geocoder.Name(), conf.RateLimit.RequestsPerSecond, l1MaxSize)
+
+	return &Service{
+		logger:   logger,
+		conf:     conf,
+		geocoder: geocoder,
+		limiter:  limiter,
+		l1Cache:  l1Cache,
+		l1TTL:    l1TTL,
+		l2Repo:   l2Repo,
+	}, nil
+}
+
+// GeocodeAddress geocodes a single address with caching and rate limiting.
+// Returns nil if geocoding fails or is disabled.
+func (s *Service) GeocodeAddress(ctx context.Context, addr search.Address) (*Coordinates, error) {
+	if s == nil {
+		return nil, nil
+	}
+
+	ctx, span := telemetry.StartSpan(ctx, "geocode-address", trace.WithAttributes(
+		attribute.String("geocoder.provider", s.geocoder.Name()),
+	))
+	defer span.End()
+
+	cacheKey := s.addressCacheKey(addr)
+
+	// Check L1 cache
+	if coords := s.checkL1Cache(cacheKey); coords != nil {
+		span.SetAttributes(attribute.String("geocoder.cache", "l1-hit"))
+		return coords, nil
+	}
+
+	// Check L2 cache
+	if s.l2Repo != nil {
+		coords, err := s.l2Repo.Get(ctx, cacheKey)
+		if err == nil && coords != nil {
+			s.setL1Cache(cacheKey, coords)
+			span.SetAttributes(attribute.String("geocoder.cache", "l2-hit"))
+			return coords, nil
+		}
+	}
+
+	span.SetAttributes(attribute.String("geocoder.cache", "miss"))
+
+	// Rate limit before calling external service
+	if err := s.limiter.Wait(ctx); err != nil {
+		return nil, fmt.Errorf("rate limit wait: %w", err)
+	}
+
+	// Call geocoder
+	coords, err := s.geocoder.Geocode(ctx, addr)
+	if err != nil {
+		s.logger.Warn().LogErrorf("geocoding failed for address %q: %v", addr.Format(), err)
+		return nil, nil // Graceful degradation
+	}
+
+	if coords != nil {
+		// Store in L1 cache
+		s.setL1Cache(cacheKey, coords)
+
+		// Store in L2 cache
+		if s.l2Repo != nil {
+			if err := s.l2Repo.Set(ctx, cacheKey, coords); err != nil {
+				s.logger.Warn().LogErrorf("failed to store in L2 cache: %v", err)
+			}
+		}
+	}
+
+	return coords, nil
+}
+
+// GeocodeAddresses geocodes multiple addresses and returns them with coordinates populated.
+// This method is the primary integration point for entity mapping.
+func (s *Service) GeocodeAddresses(ctx context.Context, addresses []search.Address) []search.Address {
+	if s == nil || len(addresses) == 0 {
+		return addresses
+	}
+
+	result := make([]search.Address, len(addresses))
+	copy(result, addresses)
+
+	for i := range result {
+		coords, err := s.GeocodeAddress(ctx, result[i])
+		if err != nil {
+			continue
+		}
+		if coords != nil {
+			result[i].Latitude = coords.Latitude
+			result[i].Longitude = coords.Longitude
+		}
+	}
+
+	return result
+}
+
+// addressCacheKey generates a normalized cache key for an address.
+func (s *Service) addressCacheKey(addr search.Address) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+		addr.Line1, addr.Line2, addr.City,
+		addr.PostalCode, addr.State, addr.Country)
+}
+
+// checkL1Cache returns cached coordinates if present and not expired.
+func (s *Service) checkL1Cache(key string) *Coordinates {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if entry, ok := s.l1Cache.Get(key); ok {
+		if time.Since(entry.timestamp) < s.l1TTL {
+			return entry.coords
+		}
+		// TTL expired, remove from cache
+		s.l1Cache.Remove(key)
+	}
+	return nil
+}
+
+// setL1Cache stores coordinates in the L1 cache.
+func (s *Service) setL1Cache(key string, coords *Coordinates) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.l1Cache.Add(key, cacheEntry{
+		coords:    coords,
+		timestamp: time.Now(),
+	})
+}
+
+// createGeocoder creates a geocoder based on provider configuration.
+func createGeocoder(conf ProviderConfig) (Geocoder, error) {
+	switch conf.Name {
+	case "opencage":
+		return NewOpenCageGeocoder(conf)
+	case "google":
+		return NewGoogleGeocoder(conf)
+	case "nominatim":
+		return NewNominatimGeocoder(conf)
+	case "":
+		return nil, fmt.Errorf("geocoding provider name is required")
+	default:
+		return nil, fmt.Errorf("unknown geocoding provider: %s", conf.Name)
+	}
+}

--- a/internal/geocoding/service_test.go
+++ b/internal/geocoding/service_test.go
@@ -1,0 +1,134 @@
+package geocoding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_Disabled(t *testing.T) {
+	conf := Config{Enabled: false}
+	svc, err := NewService(log.NewTestLogger(), conf, nil)
+	require.NoError(t, err)
+	require.Nil(t, svc)
+}
+
+func TestService_GeocodeAddress_NilService(t *testing.T) {
+	var svc *Service
+	coords, err := svc.GeocodeAddress(context.Background(), search.Address{})
+	require.NoError(t, err)
+	require.Nil(t, coords)
+}
+
+func TestService_GeocodeAddresses_NilService(t *testing.T) {
+	var svc *Service
+	addresses := []search.Address{{Line1: "123 Main St"}}
+	result := svc.GeocodeAddresses(context.Background(), addresses)
+	require.Equal(t, addresses, result)
+}
+
+func TestService_AddressCacheKey(t *testing.T) {
+	svc := &Service{}
+
+	addr1 := search.Address{Line1: "123 Main", City: "NYC", Country: "US"}
+	addr2 := search.Address{Line1: "123 Main", City: "NYC", Country: "US"}
+	addr3 := search.Address{Line1: "456 Oak", City: "LA", Country: "US"}
+
+	key1 := svc.addressCacheKey(addr1)
+	key2 := svc.addressCacheKey(addr2)
+	key3 := svc.addressCacheKey(addr3)
+
+	require.Equal(t, key1, key2, "same addresses should have same cache key")
+	require.NotEqual(t, key1, key3, "different addresses should have different cache keys")
+}
+
+func TestService_L1Cache(t *testing.T) {
+	conf := Config{
+		Enabled: true,
+		Provider: ProviderConfig{
+			Name:   "nominatim", // Nominatim doesn't require API key
+			APIKey: "",
+		},
+		RateLimit: RateLimitConfig{
+			RequestsPerSecond: 10,
+			Burst:             10,
+		},
+		Cache: CacheConfig{
+			L1MaxSize: 100,
+			L1TTL:     time.Hour,
+		},
+	}
+
+	svc, err := NewService(log.NewTestLogger(), conf, nil)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	// Test cache key generation
+	addr := search.Address{
+		Line1:   "123 Main St",
+		City:    "New York",
+		State:   "NY",
+		Country: "US",
+	}
+
+	key := svc.addressCacheKey(addr)
+	require.NotEmpty(t, key)
+
+	// Test L1 cache operations
+	coords := &Coordinates{Latitude: 40.7128, Longitude: -74.0060, Accuracy: "rooftop"}
+	svc.setL1Cache(key, coords)
+
+	cached := svc.checkL1Cache(key)
+	require.NotNil(t, cached)
+	require.Equal(t, 40.7128, cached.Latitude)
+	require.Equal(t, -74.0060, cached.Longitude)
+	require.Equal(t, "rooftop", cached.Accuracy)
+}
+
+func TestService_L1Cache_TTLExpiration(t *testing.T) {
+	conf := Config{
+		Enabled: true,
+		Provider: ProviderConfig{
+			Name: "nominatim",
+		},
+		RateLimit: RateLimitConfig{
+			RequestsPerSecond: 10,
+			Burst:             10,
+		},
+		Cache: CacheConfig{
+			L1MaxSize: 100,
+			L1TTL:     1 * time.Millisecond, // Very short TTL for testing
+		},
+	}
+
+	svc, err := NewService(log.NewTestLogger(), conf, nil)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	key := "test-key"
+	coords := &Coordinates{Latitude: 40.7128, Longitude: -74.0060}
+	svc.setL1Cache(key, coords)
+
+	// Wait for TTL to expire
+	time.Sleep(10 * time.Millisecond)
+
+	cached := svc.checkL1Cache(key)
+	require.Nil(t, cached, "cache entry should be expired")
+}
+
+func TestDefaultConfig(t *testing.T) {
+	conf := DefaultConfig()
+
+	require.False(t, conf.Enabled)
+	require.Equal(t, "opencage", conf.Provider.Name)
+	require.Equal(t, 10*time.Second, conf.Provider.Timeout)
+	require.Equal(t, float64(1), conf.RateLimit.RequestsPerSecond)
+	require.Equal(t, 5, conf.RateLimit.Burst)
+	require.Equal(t, 10000, conf.Cache.L1MaxSize)
+	require.Equal(t, 24*time.Hour, conf.Cache.L1TTL)
+	require.True(t, conf.Cache.L2Enabled)
+}

--- a/internal/ofactest/ofactest.go
+++ b/internal/ofactest/ofactest.go
@@ -40,7 +40,7 @@ func GetDownloader(tb testing.TB) download.Downloader {
 		}
 		conf.IncludedLists = append(conf.IncludedLists, search.SourceUSOFAC)
 
-		dl, err := download.NewDownloader(logger, conf)
+		dl, err := download.NewDownloader(logger, conf, nil)
 		require.NoError(tb, err)
 
 		ofacDownloader = dl

--- a/internal/ofactest/ofactest_test.go
+++ b/internal/ofactest/ofactest_test.go
@@ -30,7 +30,7 @@ func TestOFACTest_Sample(t *testing.T) {
 			IncludedLists: []search.SourceList{
 				search.SourceUSOFAC,
 			},
-		})
+		}, nil)
 	} else {
 		// Use a mock downloader with OFAC files from ./pkg/sources/ofac/testdata/
 		dl = ofactest.GetDownloader(t)

--- a/migrations/002_create_geocoding_cache.down.mysql.sql
+++ b/migrations/002_create_geocoding_cache.down.mysql.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS geocoding_cache;

--- a/migrations/002_create_geocoding_cache.down.postgres.sql
+++ b/migrations/002_create_geocoding_cache.down.postgres.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS geocoding_cache;

--- a/migrations/002_create_geocoding_cache.up.mysql.sql
+++ b/migrations/002_create_geocoding_cache.up.mysql.sql
@@ -1,0 +1,12 @@
+-- Geocoding cache table for persistent storage of geocoding results.
+-- This reduces API calls to geocoding providers by caching results.
+CREATE TABLE geocoding_cache (
+    cache_key  VARCHAR(512) NOT NULL,
+    latitude   DOUBLE NOT NULL,
+    longitude  DOUBLE NOT NULL,
+    accuracy   VARCHAR(20) NOT NULL DEFAULT 'unknown',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (cache_key),
+    INDEX geocoding_cache_created_at_idx (created_at)
+);

--- a/migrations/002_create_geocoding_cache.up.postgres.sql
+++ b/migrations/002_create_geocoding_cache.up.postgres.sql
@@ -1,0 +1,11 @@
+-- Geocoding cache table for persistent storage of geocoding results.
+-- This reduces API calls to geocoding providers by caching results.
+CREATE TABLE geocoding_cache (
+    cache_key  VARCHAR(512) NOT NULL PRIMARY KEY,
+    latitude   DOUBLE PRECISION NOT NULL,
+    longitude  DOUBLE PRECISION NOT NULL,
+    accuracy   VARCHAR(20) NOT NULL DEFAULT 'unknown',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX geocoding_cache_created_at_idx ON geocoding_cache (created_at);


### PR DESCRIPTION
Add geocoding service to populate Latitude and Longitude fields in Address structs during data ingestion. The service supports multiple providers (OpenCage, Google Maps, Nominatim) with two-level caching and rate limiting.

Features:
- Geocoder interface with three provider implementations
- L1 cache (in-memory LRU with TTL) for fast lookups
- L2 cache (PostgreSQL/MySQL) for persistence across restarts
- Configurable rate limiting to respect API quotas
- Graceful degradation when geocoding fails