### PR TITLE
feat: add OpenSanctions PEP list support

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -92,11 +92,12 @@ PostalPool is an experiment for improving address parsing. It's optional configu
 
 ### Included Lists
 
-| List ID      | Name                                       | Source                                                   |
-|--------------|--------------------------------------------|----------------------------------------------------------|
-| `us_ofac`    | US Office of Foreign Assets Control (OFAC) | [URL](https://ofac.treasury.gov/sanctions-list-service)  |
-| `us_non_sdn` | US Office of Foreign Assets Control (OFAC) | [URL](https://ofac.treasury.gov/sanctions-list-service)  |
-| `us_csl`     | Consolidated Screening List (CSL)          | [URL](https://www.trade.gov/consolidated-screening-list) |
+| List ID             | Name                                       | Source                                                   |
+|---------------------|--------------------------------------------|----------------------------------------------------------|
+| `us_ofac`           | US Office of Foreign Assets Control (OFAC) | [URL](https://ofac.treasury.gov/sanctions-list-service)  |
+| `us_non_sdn`        | US Office of Foreign Assets Control (OFAC) | [URL](https://ofac.treasury.gov/sanctions-list-service)  |
+| `us_csl`            | Consolidated Screening List (CSL)          | [URL](https://www.trade.gov/consolidated-screening-list) |
+| `opensanctions_pep` | OpenSanctions Politically Exposed Persons  | [URL](https://www.opensanctions.org/datasets/peps/)      |
 
 ### Environment Variables
 
@@ -148,10 +149,12 @@ By default Watchman does not employ TF-IDF, but it can be enabled and configured
 | `EU_CSL_TOKEN`           | Token used to download the EU Consolidated Screening List           | `<valid-token>`                                                                 |
 | `EU_CSL_DOWNLOAD_URL`    | Use an alternate URL for downloading EU Consolidated Screening List | Subresource of `webgate.ec.europa.eu`                                           |
 | `UK_CSL_DOWNLOAD_URL`    | Use an alternate URL for downloading UK Consolidated Screening List | Subresource of `www.gov.uk`                                                     |
-| `UK_SANCTIONS_LIST_URL`  | Use an alternate URL for downloading UK Sanctions List              | Subresource of `www.gov.uk`                                                     |
-| `WITH_UK_SANCTIONS_LIST` | Download and parse the UK Sanctions List on startup.                | Default: `false`                                                                |
-| `US_CSL_DOWNLOAD_URL`    | Use an alternate URL for downloading US Consolidated Screening List | Subresource of `api.trade.gov`                                                  |
-| `CSL_DOWNLOAD_TEMPLATE`  | Same as `US_CSL_DOWNLOAD_URL`                                       |                                                                                 |
+| `UK_SANCTIONS_LIST_URL`      | Use an alternate URL for downloading UK Sanctions List              | Subresource of `www.gov.uk`                                                     |
+| `WITH_UK_SANCTIONS_LIST`     | Download and parse the UK Sanctions List on startup.                | Default: `false`                                                                |
+| `US_CSL_DOWNLOAD_URL`        | Use an alternate URL for downloading US Consolidated Screening List | Subresource of `api.trade.gov`                                                  |
+| `CSL_DOWNLOAD_TEMPLATE`      | Same as `US_CSL_DOWNLOAD_URL`                                       |                                                                                 |
+| `OPENSANCTIONS_API_KEY`      | API key for OpenSanctions authenticated access (optional)           | Empty                                                                           |
+| `OPENSANCTIONS_DOWNLOAD_URL` | Use an alternate URL for downloading OpenSanctions PEP list         | `https://data.opensanctions.org/datasets/latest/peps/senzing.json`              |
 
 ## Data persistence
 

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -160,6 +160,21 @@ func (dl *downloader) RefreshAll(ctx context.Context) (Stats, error) {
 		return nil
 	})
 
+	// OpenSanctions PEP Records
+	if slices.Contains(requestedLists, search.SourceOpenSanctionsPEP) {
+		listsLoaded = append(listsLoaded, search.SourceOpenSanctionsPEP)
+
+		producerWg.Add(1)
+		g.Go(func() error {
+			defer producerWg.Done()
+			err := loadOpenSanctionsPEPRecords(ctx, logger, dl.conf, preparedLists)
+			if err != nil {
+				return fmt.Errorf("loading OpenSanctions PEP records: %w", err)
+			}
+			return nil
+		})
+	}
+
 	// Compare the configured lists against those we actually loaded.
 	// Any extra lists are an error as we don't want to silently ignore them.
 	if len(listsLoaded) > len(requestedLists) {

--- a/internal/download/download_opensanctions.go
+++ b/internal/download/download_opensanctions.go
@@ -1,0 +1,58 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/telemetry"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/moov-io/watchman/pkg/sources/opensanctions"
+)
+
+func loadOpenSanctionsPEPRecords(ctx context.Context, logger log.Logger, conf Config, responseCh chan preparedList) error {
+	ctx, span := telemetry.StartSpan(ctx, "load-opensanctions-pep-records")
+	defer span.End()
+
+	start := time.Now()
+	files, err := opensanctions.Download(ctx, logger, initialDataDirectory(conf))
+	if err != nil {
+		return fmt.Errorf("OpenSanctions PEP download: %w", err)
+	}
+	defer files.Close()
+
+	span.AddEvent("finished downloading")
+
+	if len(files) == 0 {
+		return fmt.Errorf("unexpected %d OpenSanctions PEP files found", len(files))
+	}
+
+	logger.Debug().Logf("finished OpenSanctions PEP download: %v", time.Since(start))
+	start = time.Now()
+
+	res, err := opensanctions.Read(files)
+	if err != nil {
+		return fmt.Errorf("parsing OpenSanctions PEP: %w", err)
+	}
+	span.AddEvent("finished parsing")
+
+	logger.Debug().Logf("finished OpenSanctions PEP preparation: %v", time.Since(start))
+	span.AddEvent("finished OpenSanctions PEP preparation")
+
+	if len(res.Entities) == 0 && conf.ErrorOnEmptyList {
+		return errors.New("no entities parsed from OpenSanctions PEP")
+	}
+
+	responseCh <- preparedList{
+		ListName: search.SourceOpenSanctionsPEP,
+		Entities: res.Entities,
+		Hash:     res.ListHash,
+	}
+	return nil
+}

--- a/pkg/search/models.go
+++ b/pkg/search/models.go
@@ -63,6 +63,8 @@ var (
 	SourceUSOFAC   SourceList = "us_ofac"
 	SourceUSNonSDN SourceList = "us_non_sdn"
 
+	SourceOpenSanctionsPEP SourceList = "opensanctions_pep"
+
 	sourceEmpty SourceList = ""
 )
 

--- a/pkg/sources/display/display.go
+++ b/pkg/sources/display/display.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moov-io/watchman/pkg/search"
 	"github.com/moov-io/watchman/pkg/sources/csl_us"
 	"github.com/moov-io/watchman/pkg/sources/ofac"
+	"github.com/moov-io/watchman/pkg/sources/opensanctions"
 )
 
 // DetailsURL returns a URL where you can view the entity on the source's website
@@ -22,6 +23,9 @@ func DetailsURL(entity search.Entity[search.Value]) string {
 
 	case search.SourceUSOFAC, search.SourceUSNonSDN:
 		return ofac.DetailsURL(entity.SourceID)
+
+	case search.SourceOpenSanctionsPEP:
+		return opensanctions.DetailsURL(entity.SourceID)
 
 	case search.SourceAPIRequest:
 		// do nothing

--- a/pkg/sources/opensanctions/display.go
+++ b/pkg/sources/opensanctions/display.go
@@ -1,0 +1,18 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"fmt"
+)
+
+const (
+	baseDetailsURL = "https://www.opensanctions.org/entities/"
+)
+
+// DetailsURL returns the OpenSanctions entity page URL for a given entity ID
+func DetailsURL(entityID string) string {
+	return fmt.Sprintf("%s%s/", baseDetailsURL, entityID)
+}

--- a/pkg/sources/opensanctions/display_test.go
+++ b/pkg/sources/opensanctions/display_test.go
@@ -1,0 +1,34 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetailsURL(t *testing.T) {
+	tests := []struct {
+		entityID string
+		expected string
+	}{
+		{
+			entityID: "Q123456",
+			expected: "https://www.opensanctions.org/entities/Q123456/",
+		},
+		{
+			entityID: "NK-abc-123",
+			expected: "https://www.opensanctions.org/entities/NK-abc-123/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.entityID, func(t *testing.T) {
+			url := DetailsURL(tc.entityID)
+			require.Equal(t, tc.expected, url)
+		})
+	}
+}

--- a/pkg/sources/opensanctions/download.go
+++ b/pkg/sources/opensanctions/download.go
@@ -1,0 +1,51 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/strx"
+	"github.com/moov-io/watchman/pkg/download"
+)
+
+var (
+	// OpenSanctions PEP dataset in Senzing format
+	// https://www.opensanctions.org/datasets/peps/
+	publicDownloadURL = "https://data.opensanctions.org/datasets/latest/peps/senzing.json"
+	downloadURL       = strx.Or(os.Getenv("OPENSANCTIONS_DOWNLOAD_URL"), publicDownloadURL)
+
+	// API key for authenticated access
+	// https://www.opensanctions.org/docs/api/
+	apiKey = os.Getenv("OPENSANCTIONS_API_KEY")
+)
+
+func Download(ctx context.Context, logger log.Logger, initialDir string) (download.Files, error) {
+	dl := download.New(logger, nil)
+
+	targetURL := downloadURL
+	if apiKey != "" {
+		// Use API with authentication
+		parsedURL, err := url.Parse(downloadURL)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse OpenSanctions download URL: %w", err)
+		}
+		q := parsedURL.Query()
+		q.Set("api_key", apiKey)
+		parsedURL.RawQuery = q.Encode()
+		targetURL = parsedURL.String()
+
+		logger.Info().Log("using OpenSanctions API with authentication")
+	}
+
+	addrs := make(map[string]string)
+	addrs["peps_senzing.json"] = targetURL
+
+	return dl.GetFiles(ctx, initialDir, addrs)
+}

--- a/pkg/sources/opensanctions/download_test.go
+++ b/pkg/sources/opensanctions/download_test.go
@@ -1,0 +1,108 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/base/log"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping download test in short mode (file is ~670MB)")
+	}
+
+	files, err := Download(context.Background(), log.NewNopLogger(), "")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	file, found := files["peps_senzing.json"]
+	require.True(t, found)
+	require.NotNil(t, file)
+
+	// Read first 1KB to verify it's valid JSON
+	// Note: Download() returns a streaming response, so only the bytes we read
+	// are actually downloaded. Full file (~670MB) is only downloaded when fully read.
+	buf := make([]byte, 1024)
+	n, err := file.Read(buf)
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+
+	// Should start with '[' (JSON array) or '{' (JSON object)
+	content := string(buf[:n])
+	require.True(t, strings.HasPrefix(strings.TrimSpace(content), "[") ||
+		strings.HasPrefix(strings.TrimSpace(content), "{"),
+		"expected JSON content, got: %s", content[:min(100, len(content))])
+
+	require.NoError(t, file.Close())
+}
+
+// TestDownloadAndParse downloads and parses the full OpenSanctions PEP file.
+// This test is slow (~670MB download) and should only be run manually.
+func TestDownloadAndParse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping full download test in short mode (file is ~670MB)")
+	}
+	if os.Getenv("TEST_OPENSANCTIONS_FULL") == "" {
+		t.Skip("set TEST_OPENSANCTIONS_FULL=1 to run this test")
+	}
+
+	files, err := Download(context.Background(), log.NewNopLogger(), "")
+	require.NoError(t, err)
+	defer files.Close()
+
+	results, err := Read(files)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+
+	// OpenSanctions PEP dataset should have ~2M entities
+	t.Logf("Downloaded and parsed %d entities", len(results.Entities))
+	require.Greater(t, len(results.Entities), 100000, "expected at least 100k entities")
+
+	// Verify hash was computed
+	require.NotEmpty(t, results.ListHash)
+	t.Logf("List hash: %s", results.ListHash)
+}
+
+func TestDownload_initialDir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "initial-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	mk := func(t *testing.T, name string, body string) {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+
+	// create the file locally
+	mk(t, "peps_senzing.json", `[{"DATA_SOURCE":"TEST","RECORD_ID":"1"}]`)
+
+	files, err := Download(context.Background(), log.NewNopLogger(), dir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	for filename, fd := range files {
+		if strings.EqualFold("peps_senzing.json", filepath.Base(filename)) {
+			bs, err := io.ReadAll(fd)
+			require.NoError(t, err)
+
+			require.Equal(t, `[{"DATA_SOURCE":"TEST","RECORD_ID":"1"}]`, string(bs))
+		} else {
+			t.Fatalf("unknown file: %v", filename)
+		}
+	}
+}

--- a/pkg/sources/opensanctions/reader.go
+++ b/pkg/sources/opensanctions/reader.go
@@ -1,0 +1,61 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/moov-io/watchman/pkg/sources/senzing"
+	"github.com/moov-io/watchman/pkg/download"
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// Results holds the parsed OpenSanctions PEP data and its hash
+type Results struct {
+	Entities []search.Entity[search.Value]
+	ListHash string
+}
+
+// Read processes the downloaded Senzing JSON file and returns parsed entities
+func Read(files download.Files) (*Results, error) {
+	for filename, contents := range files {
+		switch strings.ToLower(filename) {
+		case "peps_senzing.json":
+			return parseSenzingJSON(contents)
+		default:
+			return nil, fmt.Errorf("unknown file %s", filename)
+		}
+	}
+	return nil, errors.New("no files provided")
+}
+
+// parseSenzingJSON reads and parses the Senzing JSON file
+func parseSenzingJSON(contents io.ReadCloser) (*Results, error) {
+	defer contents.Close()
+
+	// Read all content for hashing
+	var buf bytes.Buffer
+	tee := io.TeeReader(contents, &buf)
+
+	// Use the existing Senzing reader to parse entities
+	entities, err := senzing.ReadEntities(tee, search.SourceOpenSanctionsPEP)
+	if err != nil {
+		return nil, fmt.Errorf("parsing senzing json: %w", err)
+	}
+
+	// Compute hash of the file content
+	listHash := sha256.Sum256(buf.Bytes())
+
+	return &Results{
+		Entities: entities,
+		ListHash: hex.EncodeToString(listHash[:]),
+	}, nil
+}

--- a/pkg/sources/opensanctions/reader_test.go
+++ b/pkg/sources/opensanctions/reader_test.go
@@ -1,0 +1,77 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package opensanctions
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/watchman/pkg/download"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRead(t *testing.T) {
+	testdataPath := filepath.Join("..", "..", "..", "test", "testdata", "opensanctions", "peps_senzing.json")
+
+	fd, err := os.Open(testdataPath)
+	require.NoError(t, err)
+	defer fd.Close()
+
+	files := make(download.Files)
+	files["peps_senzing.json"] = io.NopCloser(fd)
+
+	results, err := Read(files)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+
+	// Check that we have the expected number of entities
+	require.Len(t, results.Entities, 3)
+
+	// Check that the list hash was computed
+	require.NotEmpty(t, results.ListHash)
+
+	// Verify the first entity (person with first/last name)
+	entity1 := results.Entities[0]
+	require.Equal(t, search.SourceOpenSanctionsPEP, entity1.Source)
+	require.Equal(t, "Q123456", entity1.SourceID)
+	require.Equal(t, search.EntityPerson, entity1.Type)
+	require.Equal(t, "John Smith", entity1.Name)
+	require.NotNil(t, entity1.Person)
+
+	// Verify the second entity (person with full name)
+	entity2 := results.Entities[1]
+	require.Equal(t, "Q789012", entity2.SourceID)
+	require.Equal(t, search.EntityPerson, entity2.Type)
+	require.Equal(t, "Maria Garcia Lopez", entity2.Name)
+
+	// Verify the third entity (organization)
+	entity3 := results.Entities[2]
+	require.Equal(t, "Q345678", entity3.SourceID)
+	require.Equal(t, search.EntityBusiness, entity3.Type)
+	require.Equal(t, "Ministry of Finance", entity3.Name)
+}
+
+func TestRead_EmptyFiles(t *testing.T) {
+	files := make(download.Files)
+
+	results, err := Read(files)
+	require.Error(t, err)
+	require.Nil(t, results)
+	require.Contains(t, err.Error(), "no files provided")
+}
+
+func TestRead_UnknownFile(t *testing.T) {
+	files := make(download.Files)
+	files["unknown.json"] = io.NopCloser(nil)
+
+	results, err := Read(files)
+	require.Error(t, err)
+	require.Nil(t, results)
+	require.Contains(t, err.Error(), "unknown file")
+}

--- a/test/testdata/opensanctions/peps_senzing.json
+++ b/test/testdata/opensanctions/peps_senzing.json
@@ -1,0 +1,32 @@
+[
+  {
+    "DATA_SOURCE": "OPENSANCTIONS_PEP",
+    "RECORD_ID": "Q123456",
+    "RECORD_TYPE": "PERSON",
+    "NAME_FIRST": "John",
+    "NAME_LAST": "Smith",
+    "DATE_OF_BIRTH": "1965-03-15",
+    "NATIONALITY": "US",
+    "ADDR_CITY": "Washington",
+    "ADDR_STATE": "DC",
+    "ADDR_COUNTRY": "United States"
+  },
+  {
+    "DATA_SOURCE": "OPENSANCTIONS_PEP",
+    "RECORD_ID": "Q789012",
+    "RECORD_TYPE": "PERSON",
+    "NAME_FULL": "Maria Garcia Lopez",
+    "DATE_OF_BIRTH": "1970-07-22",
+    "NATIONALITY": "ES",
+    "ADDR_CITY": "Madrid",
+    "ADDR_COUNTRY": "Spain"
+  },
+  {
+    "DATA_SOURCE": "OPENSANCTIONS_PEP",
+    "RECORD_ID": "Q345678",
+    "RECORD_TYPE": "ORGANIZATION",
+    "NAME_ORG": "Ministry of Finance",
+    "ADDR_CITY": "Berlin",
+    "ADDR_COUNTRY": "Germany"
+  }
+]


### PR DESCRIPTION
Adds support for OpenSanctions Politically Exposed Persons (PEP) dataset. Uses existing Senzing reader for parsing.