### PR TITLE
feat: add FinCEN 311/9714 Special Measures list

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -144,6 +144,22 @@ func (dl *downloader) RefreshAll(ctx context.Context) (Stats, error) {
 		})
 	}
 
+	// FinCEN 311 Records
+	if slices.Contains(requestedLists, search.SourceUSFinCEN311) {
+		listsLoaded = append(listsLoaded, search.SourceUSFinCEN311)
+
+		producerWg.Add(1)
+		g.Go(func() error {
+			defer producerWg.Done()
+
+			err := loadFinCEN311Records(ctx, logger, dl.conf, preparedLists)
+			if err != nil {
+				return fmt.Errorf("loading FinCEN 311 records: %w", err)
+			}
+			return nil
+		})
+	}
+
 	// Senzing lists
 	for idx := range dl.conf.Senzing {
 		listsLoaded = append(listsLoaded, dl.conf.Senzing[idx].SourceList)

--- a/internal/download/download_fincen311.go
+++ b/internal/download/download_fincen311.go
@@ -1,0 +1,59 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/telemetry"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/moov-io/watchman/pkg/sources/fincen_311"
+)
+
+func loadFinCEN311Records(ctx context.Context, logger log.Logger, conf Config, responseCh chan preparedList) error {
+	ctx, span := telemetry.StartSpan(ctx, "load-fincen-311-records")
+	defer span.End()
+
+	start := time.Now()
+	files, err := fincen_311.Download(ctx, logger, initialDataDirectory(conf))
+	if err != nil {
+		return fmt.Errorf("FinCEN 311 download: %v", err)
+	}
+	defer files.Close()
+
+	span.AddEvent("finished downloading")
+
+	if len(files) == 0 {
+		return fmt.Errorf("unexpected %d FinCEN 311 files found", len(files))
+	}
+
+	logger.Debug().Logf("finished FinCEN 311 download: %v", time.Since(start))
+	start = time.Now()
+
+	res, err := fincen_311.Read(files)
+	if err != nil {
+		return fmt.Errorf("parsing FinCEN 311: %w", err)
+	}
+	span.AddEvent("finished parsing")
+
+	entities := fincen_311.ConvertSpecialMeasures(res)
+
+	logger.Debug().Logf("finished FinCEN 311 preparation: %v", time.Since(start))
+	span.AddEvent("finished FinCEN 311 preparation")
+
+	if len(entities) == 0 && conf.ErrorOnEmptyList {
+		return errors.New("no entities parsed from FinCEN 311")
+	}
+
+	responseCh <- preparedList{
+		ListName: search.SourceUSFinCEN311,
+		Entities: entities,
+		Hash:     res.ListHash,
+	}
+	return nil
+}

--- a/pkg/search/models.go
+++ b/pkg/search/models.go
@@ -57,11 +57,12 @@ type SourceList string
 var (
 	SourceAPIRequest SourceList = "api-request"
 
-	SourceEUCSL    SourceList = "eu_csl"
-	SourceUKCSL    SourceList = "uk_csl"
-	SourceUSCSL    SourceList = "us_csl"
-	SourceUSOFAC   SourceList = "us_ofac"
-	SourceUSNonSDN SourceList = "us_non_sdn"
+	SourceEUCSL       SourceList = "eu_csl"
+	SourceUKCSL       SourceList = "uk_csl"
+	SourceUSCSL       SourceList = "us_csl"
+	SourceUSOFAC      SourceList = "us_ofac"
+	SourceUSNonSDN    SourceList = "us_non_sdn"
+	SourceUSFinCEN311 SourceList = "us_fincen_311"
 
 	sourceEmpty SourceList = ""
 )

--- a/pkg/sources/fincen_311/download.go
+++ b/pkg/sources/fincen_311/download.go
@@ -1,0 +1,28 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"context"
+	"os"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/strx"
+	"github.com/moov-io/watchman/pkg/download"
+)
+
+var (
+	publicFinCEN311URL = "https://www.fincen.gov/resources/statutes-and-regulations/311-and-9714-special-measures"
+	fincen311URL       = strx.Or(os.Getenv("FINCEN_311_DOWNLOAD_URL"), publicFinCEN311URL)
+)
+
+// Download fetches the FinCEN 311/9714 Special Measures HTML page
+func Download(ctx context.Context, logger log.Logger, initialDir string) (download.Files, error) {
+	dl := download.New(logger, nil)
+
+	addrs := make(map[string]string)
+	addrs["fincen_311.html"] = fincen311URL
+
+	return dl.GetFiles(ctx, initialDir, addrs)
+}

--- a/pkg/sources/fincen_311/download_test.go
+++ b/pkg/sources/fincen_311/download_test.go
@@ -1,0 +1,85 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/base/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	files, err := Download(context.Background(), log.NewNopLogger(), "")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	file, found := files["fincen_311.html"]
+	require.True(t, found)
+	require.NotNil(t, file)
+	require.NoError(t, file.Close())
+}
+
+func TestFullPipeline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Download real page
+	files, err := Download(context.Background(), log.NewNopLogger(), "")
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	// Parse HTML
+	data, err := Read(files)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.NotEmpty(t, data.ListHash)
+
+	// Should have at least 10 entries (there are ~40+ on the real page)
+	require.GreaterOrEqual(t, len(data.SpecialMeasures), 10,
+		"expected at least 10 special measures entries")
+
+	// Convert to entities
+	entities := ConvertSpecialMeasures(data)
+	require.Len(t, entities, len(data.SpecialMeasures))
+
+	// Verify some known entities exist
+	var foundIran, foundBank bool
+	for _, e := range entities {
+		nameLower := strings.ToLower(e.Name)
+		if strings.Contains(nameLower, "iran") {
+			foundIran = true
+		}
+		if strings.Contains(nameLower, "bank") {
+			foundBank = true
+		}
+	}
+
+	require.True(t, foundIran, "expected to find Iran in the list")
+	require.True(t, foundBank, "expected to find at least one bank in the list")
+
+	// Log some stats for debugging
+	t.Logf("Parsed %d special measures entries", len(data.SpecialMeasures))
+
+	var institutions, jurisdictions, transactions int
+	for _, sm := range data.SpecialMeasures {
+		switch sm.EntityType {
+		case SMTypeFinancialInstitution:
+			institutions++
+		case SMTypeJurisdiction:
+			jurisdictions++
+		case SMTypeTransactionClass:
+			transactions++
+		}
+	}
+	t.Logf("Types: %d institutions, %d jurisdictions, %d transaction classes",
+		institutions, jurisdictions, transactions)
+}

--- a/pkg/sources/fincen_311/mapper.go
+++ b/pkg/sources/fincen_311/mapper.go
@@ -1,0 +1,137 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"strings"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// ConvertSpecialMeasures converts parsed data to search entities
+func ConvertSpecialMeasures(data *ListData) []search.Entity[search.Value] {
+	var out []search.Entity[search.Value]
+	for _, sm := range data.SpecialMeasures {
+		out = append(out, ToEntity(sm))
+	}
+	return out
+}
+
+// ToEntity converts a SpecialMeasure to a search Entity
+func ToEntity(sm SpecialMeasure) search.Entity[search.Value] {
+	entity := search.Entity[search.Value]{
+		Name:       sm.EntityName,
+		Source:     search.SourceUSFinCEN311,
+		SourceID:   generateSourceID(sm),
+		SourceData: sm,
+	}
+
+	// Map entity type based on classification
+	switch sm.EntityType {
+	case SMTypeFinancialInstitution:
+		entity.Type = search.EntityBusiness
+		entity.Business = &search.Business{
+			Name: sm.EntityName,
+		}
+
+	case SMTypeJurisdiction:
+		entity.Type = search.EntityOrganization
+		entity.Organization = &search.Organization{
+			Name: sm.EntityName,
+		}
+
+	case SMTypeTransactionClass:
+		entity.Type = search.EntityOrganization
+		entity.Organization = &search.Organization{
+			Name: sm.EntityName,
+		}
+
+	default:
+		// Default to business for unknown types
+		entity.Type = search.EntityBusiness
+		entity.Business = &search.Business{
+			Name: sm.EntityName,
+		}
+	}
+
+	// Store PDF links in Contact.Websites for audit/compliance access
+	entity.Contact = buildContactInfo(sm)
+
+	// Build sanctions info with program details
+	entity.SanctionsInfo = buildSanctionsInfo(sm)
+
+	return entity.Normalize()
+}
+
+func generateSourceID(sm SpecialMeasure) string {
+	// Create a stable ID from the entity name
+	id := strings.ToLower(sm.EntityName)
+	id = strings.ReplaceAll(id, " ", "_")
+	id = strings.ReplaceAll(id, "'", "")
+	id = strings.ReplaceAll(id, ",", "")
+	id = strings.ReplaceAll(id, ".", "")
+	id = strings.ReplaceAll(id, "(", "")
+	id = strings.ReplaceAll(id, ")", "")
+	return "fincen311_" + id
+}
+
+func buildContactInfo(sm SpecialMeasure) search.ContactInfo {
+	var websites []string
+
+	// Store PDF document links as "websites" for compliance access
+	if sm.FindingURL != "" {
+		websites = append(websites, sm.FindingURL)
+	}
+	if sm.NPRMURL != "" {
+		websites = append(websites, sm.NPRMURL)
+	}
+	if sm.FinalRuleURL != "" {
+		websites = append(websites, sm.FinalRuleURL)
+	}
+	if sm.RescindedURL != "" {
+		websites = append(websites, sm.RescindedURL)
+	}
+
+	return search.ContactInfo{
+		Websites: websites,
+	}
+}
+
+func buildSanctionsInfo(sm SpecialMeasure) *search.SanctionsInfo {
+	programs := []string{"FinCEN Special Measures"}
+
+	// Add specific program based on entity type
+	switch sm.EntityType {
+	case SMTypeFinancialInstitution:
+		programs = append(programs, "Section 311")
+	case SMTypeJurisdiction:
+		programs = append(programs, "Section 311")
+	case SMTypeTransactionClass:
+		programs = append(programs, "Section 9714")
+	}
+
+	var descParts []string
+	descParts = append(descParts, "FinCEN Special Measures Target")
+
+	if sm.FindingDate != "" {
+		descParts = append(descParts, "Finding: "+sm.FindingDate)
+	}
+	if sm.FinalRuleDate != "" {
+		descParts = append(descParts, "Final Rule: "+sm.FinalRuleDate)
+	}
+	if sm.IsRescinded {
+		status := "Status: RESCINDED"
+		if sm.RescindedDate != "" {
+			status += " (" + sm.RescindedDate + ")"
+		}
+		descParts = append(descParts, status)
+	} else {
+		descParts = append(descParts, "Status: ACTIVE")
+	}
+
+	return &search.SanctionsInfo{
+		Programs:    programs,
+		Description: strings.Join(descParts, ". ") + ".",
+	}
+}

--- a/pkg/sources/fincen_311/mapper_test.go
+++ b/pkg/sources/fincen_311/mapper_test.go
@@ -1,0 +1,173 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"testing"
+
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertSpecialMeasures(t *testing.T) {
+	data := &ListData{
+		SpecialMeasures: []SpecialMeasure{
+			{
+				EntityName:    "ABLV Bank",
+				EntityType:    SMTypeFinancialInstitution,
+				FindingURL:    "https://www.fincen.gov/finding.pdf",
+				FindingDate:   "02/13/2018",
+				FinalRuleURL:  "https://www.fincen.gov/final.pdf",
+				FinalRuleDate: "06/25/2018",
+				IsRescinded:   false,
+			},
+			{
+				EntityName:    "Islamic Republic of Iran",
+				EntityType:    SMTypeJurisdiction,
+				FindingURL:    "https://www.fincen.gov/iran.pdf",
+				FindingDate:   "11/21/2011",
+				FinalRuleURL:  "https://www.fincen.gov/iran_final.pdf",
+				FinalRuleDate: "01/01/2012",
+				IsRescinded:   false,
+			},
+		},
+		ListHash: "abc123",
+	}
+
+	entities := ConvertSpecialMeasures(data)
+	require.Len(t, entities, 2)
+
+	// Check first entity
+	ablv := entities[0]
+	require.Equal(t, "ABLV Bank", ablv.Name)
+	require.Equal(t, search.SourceUSFinCEN311, ablv.Source)
+	require.Equal(t, search.EntityBusiness, ablv.Type)
+	require.NotNil(t, ablv.Business)
+	require.Equal(t, "ABLV Bank", ablv.Business.Name)
+	require.Contains(t, ablv.SourceID, "fincen311_ablv_bank")
+
+	// Check websites contain PDF links
+	require.Contains(t, ablv.Contact.Websites, "https://www.fincen.gov/finding.pdf")
+	require.Contains(t, ablv.Contact.Websites, "https://www.fincen.gov/final.pdf")
+
+	// Check sanctions info
+	require.NotNil(t, ablv.SanctionsInfo)
+	require.Contains(t, ablv.SanctionsInfo.Programs, "FinCEN Special Measures")
+	require.Contains(t, ablv.SanctionsInfo.Programs, "Section 311")
+	require.Contains(t, ablv.SanctionsInfo.Description, "ACTIVE")
+
+	// Check second entity (jurisdiction)
+	iran := entities[1]
+	require.Equal(t, "Islamic Republic of Iran", iran.Name)
+	require.Equal(t, search.EntityOrganization, iran.Type)
+	require.NotNil(t, iran.Organization)
+}
+
+func TestToEntity_FinancialInstitution(t *testing.T) {
+	sm := SpecialMeasure{
+		EntityName:    "Test Bank Ltd.",
+		EntityType:    SMTypeFinancialInstitution,
+		FindingURL:    "https://example.com/finding.pdf",
+		FindingDate:   "01/01/2020",
+		FinalRuleURL:  "https://example.com/final.pdf",
+		FinalRuleDate: "06/01/2020",
+		IsRescinded:   false,
+	}
+
+	entity := ToEntity(sm)
+
+	require.Equal(t, search.EntityBusiness, entity.Type)
+	require.NotNil(t, entity.Business)
+	require.Nil(t, entity.Organization)
+	require.Equal(t, "Test Bank Ltd.", entity.Business.Name)
+}
+
+func TestToEntity_Jurisdiction(t *testing.T) {
+	sm := SpecialMeasure{
+		EntityName:  "Test Country",
+		EntityType:  SMTypeJurisdiction,
+		IsRescinded: false,
+	}
+
+	entity := ToEntity(sm)
+
+	require.Equal(t, search.EntityOrganization, entity.Type)
+	require.NotNil(t, entity.Organization)
+	require.Nil(t, entity.Business)
+	require.Equal(t, "Test Country", entity.Organization.Name)
+}
+
+func TestToEntity_TransactionClass(t *testing.T) {
+	sm := SpecialMeasure{
+		EntityName:  "Virtual Currency Mixing",
+		EntityType:  SMTypeTransactionClass,
+		IsRescinded: false,
+	}
+
+	entity := ToEntity(sm)
+
+	require.Equal(t, search.EntityOrganization, entity.Type)
+	require.NotNil(t, entity.Organization)
+
+	// Transaction class should have Section 9714 in programs
+	require.Contains(t, entity.SanctionsInfo.Programs, "Section 9714")
+}
+
+func TestToEntity_Rescinded(t *testing.T) {
+	sm := SpecialMeasure{
+		EntityName:    "Rescinded Bank",
+		EntityType:    SMTypeFinancialInstitution,
+		FinalRuleURL:  "https://example.com/final.pdf",
+		FinalRuleDate: "01/01/2020",
+		RescindedURL:  "https://example.com/rescind.pdf",
+		RescindedDate: "12/01/2024",
+		IsRescinded:   true,
+	}
+
+	entity := ToEntity(sm)
+
+	require.Contains(t, entity.SanctionsInfo.Description, "RESCINDED")
+	require.Contains(t, entity.SanctionsInfo.Description, "12/01/2024")
+
+	// Rescinded URL should be in websites
+	require.Contains(t, entity.Contact.Websites, "https://example.com/rescind.pdf")
+}
+
+func TestGenerateSourceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"ABLV Bank", "fincen311_ablv_bank"},
+		{"Islamic Republic of Iran", "fincen311_islamic_republic_of_iran"},
+		{"Bank's Name, Inc.", "fincen311_banks_name_inc"},
+		{"Test (Entity)", "fincen311_test_entity"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := SpecialMeasure{EntityName: tc.name}
+			result := generateSourceID(sm)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildSanctionsInfo(t *testing.T) {
+	// Test financial institution
+	sm := SpecialMeasure{
+		EntityName:    "Test Bank",
+		EntityType:    SMTypeFinancialInstitution,
+		FindingDate:   "01/01/2020",
+		FinalRuleDate: "06/01/2020",
+		IsRescinded:   false,
+	}
+
+	info := buildSanctionsInfo(sm)
+	require.Contains(t, info.Programs, "FinCEN Special Measures")
+	require.Contains(t, info.Programs, "Section 311")
+	require.Contains(t, info.Description, "Finding: 01/01/2020")
+	require.Contains(t, info.Description, "Final Rule: 06/01/2020")
+	require.Contains(t, info.Description, "Status: ACTIVE")
+}

--- a/pkg/sources/fincen_311/models.go
+++ b/pkg/sources/fincen_311/models.go
@@ -1,0 +1,34 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+// SpecialMeasure represents a single FinCEN 311/9714 Special Measures entry
+type SpecialMeasure struct {
+	EntityName    string `json:"entityName"`
+	EntityType    SMType `json:"entityType"`
+	FindingURL    string `json:"findingUrl,omitempty"`
+	FindingDate   string `json:"findingDate,omitempty"`
+	NPRMURL       string `json:"nprmUrl,omitempty"`
+	NPRMDate      string `json:"nprmDate,omitempty"`
+	FinalRuleURL  string `json:"finalRuleUrl,omitempty"`
+	FinalRuleDate string `json:"finalRuleDate,omitempty"`
+	RescindedURL  string `json:"rescindedUrl,omitempty"`
+	RescindedDate string `json:"rescindedDate,omitempty"`
+	IsRescinded   bool   `json:"isRescinded"`
+}
+
+// SMType categorizes the type of special measure target
+type SMType string
+
+const (
+	SMTypeFinancialInstitution SMType = "financial_institution"
+	SMTypeJurisdiction         SMType = "jurisdiction"
+	SMTypeTransactionClass     SMType = "transaction_class"
+)
+
+// ListData holds parsed data and hash for change detection
+type ListData struct {
+	SpecialMeasures []SpecialMeasure
+	ListHash        string
+}

--- a/pkg/sources/fincen_311/reader.go
+++ b/pkg/sources/fincen_311/reader.go
@@ -1,0 +1,221 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/moov-io/watchman/pkg/download"
+
+	"github.com/antchfx/htmlquery"
+	"golang.org/x/net/html"
+)
+
+// Read parses the downloaded HTML file and extracts special measures
+func Read(files download.Files) (*ListData, error) {
+	for filename, contents := range files {
+		if strings.Contains(strings.ToLower(filename), "fincen_311") {
+			return parseHTMLContents(contents)
+		}
+	}
+	return nil, errors.New("no FinCEN 311 file found")
+}
+
+func parseHTMLContents(contents io.ReadCloser) (*ListData, error) {
+	var buf bytes.Buffer
+	buftee := io.TeeReader(contents, &buf)
+	defer contents.Close()
+
+	doc, err := htmlquery.Parse(buftee)
+	if err != nil {
+		return nil, fmt.Errorf("parsing HTML: %w", err)
+	}
+
+	measures, err := extractSpecialMeasures(doc)
+	if err != nil {
+		return nil, fmt.Errorf("extracting special measures: %w", err)
+	}
+
+	// Compute hash for change detection
+	listHash := sha256.Sum256(buf.Bytes())
+
+	return &ListData{
+		SpecialMeasures: measures,
+		ListHash:        hex.EncodeToString(listHash[:]),
+	}, nil
+}
+
+func extractSpecialMeasures(doc *html.Node) ([]SpecialMeasure, error) {
+	var measures []SpecialMeasure
+
+	// Try multiple XPath strategies for robustness
+	xpaths := []string{
+		`//table//tbody//tr`,
+		`//table//tr[position()>1]`,
+		`//div[contains(@class, 'table')]//tr`,
+		`//article//table//tr`,
+	}
+
+	var rows []*html.Node
+	var err error
+	for _, xpath := range xpaths {
+		rows, err = htmlquery.QueryAll(doc, xpath)
+		if err == nil && len(rows) > 0 {
+			break
+		}
+	}
+
+	if len(rows) == 0 {
+		return nil, errors.New("no table rows found - HTML structure may have changed")
+	}
+
+	for _, row := range rows {
+		measure, err := parseTableRow(row)
+		if err != nil {
+			// Skip malformed rows but continue processing
+			continue
+		}
+		// Skip empty names and header rows
+		if measure.EntityName != "" &&
+			!strings.EqualFold(measure.EntityName, "Entity Name") &&
+			!strings.EqualFold(measure.EntityName, "Name") {
+			measures = append(measures, measure)
+		}
+	}
+
+	if len(measures) == 0 {
+		return nil, errors.New("no valid entities parsed from HTML")
+	}
+
+	return measures, nil
+}
+
+func parseTableRow(row *html.Node) (SpecialMeasure, error) {
+	var measure SpecialMeasure
+
+	cells, _ := htmlquery.QueryAll(row, `.//td`)
+	if len(cells) < 2 {
+		return measure, errors.New("insufficient cells in row")
+	}
+
+	// Column 0: Entity Name
+	measure.EntityName = cleanText(htmlquery.InnerText(cells[0]))
+
+	// Column 1: Finding (may contain link and date)
+	if len(cells) > 1 {
+		measure.FindingURL, measure.FindingDate = extractLinkAndDate(cells[1])
+	}
+
+	// Column 2: NPRM
+	if len(cells) > 2 {
+		measure.NPRMURL, measure.NPRMDate = extractLinkAndDate(cells[2])
+	}
+
+	// Column 3: Final Rule
+	if len(cells) > 3 {
+		measure.FinalRuleURL, measure.FinalRuleDate = extractLinkAndDate(cells[3])
+	}
+
+	// Column 4: Rescinded (if exists)
+	if len(cells) > 4 {
+		measure.RescindedURL, measure.RescindedDate = extractLinkAndDate(cells[4])
+		cellText := strings.ToLower(htmlquery.InnerText(cells[4]))
+		measure.IsRescinded = measure.RescindedURL != "" ||
+			strings.Contains(cellText, "rescind") ||
+			(measure.RescindedDate != "" && measure.RescindedDate != "---")
+	}
+
+	// Classify entity type based on name
+	measure.EntityType = classifyEntityType(measure.EntityName)
+
+	return measure, nil
+}
+
+func extractLinkAndDate(cell *html.Node) (url, date string) {
+	// Look for anchor tags
+	links, _ := htmlquery.QueryAll(cell, `.//a`)
+	for _, link := range links {
+		for _, attr := range link.Attr {
+			if attr.Key == "href" && url == "" {
+				url = attr.Val
+				// Make relative URLs absolute
+				if strings.HasPrefix(url, "/") {
+					url = "https://www.fincen.gov" + url
+				}
+				break
+			}
+		}
+	}
+
+	// Extract date text
+	text := cleanText(htmlquery.InnerText(cell))
+	if text != "" && text != "---" && text != "-" {
+		date = text
+	}
+
+	return url, date
+}
+
+func classifyEntityType(name string) SMType {
+	lower := strings.ToLower(name)
+
+	// Financial Institution indicators
+	bankKeywords := []string{
+		"bank", "credit union", "financial institution",
+		"fbme", "ablv", "banca privada", "asiauniversalbank",
+		"bitzlato", "suex", "garantex", "casa de cambio",
+		"pm2btc", "liberty reserve", "delta asia",
+		"casa de bolsa", "institución de banca",
+	}
+	for _, keyword := range bankKeywords {
+		if strings.Contains(lower, keyword) {
+			return SMTypeFinancialInstitution
+		}
+	}
+
+	// Jurisdiction indicators (country/region names)
+	jurisdictionKeywords := []string{
+		"iran", "korea", "burma", "myanmar",
+		"lebanon", "venezuela", "republic of", "nauru",
+		"ukraine", "people's republic", "democratic republic",
+		"islamic republic",
+	}
+	for _, keyword := range jurisdictionKeywords {
+		if strings.Contains(lower, keyword) {
+			return SMTypeJurisdiction
+		}
+	}
+
+	// Transaction class indicators
+	transactionKeywords := []string{
+		"virtual currency", "mixing", "convertible",
+		"transaction", "class of", "gambling",
+	}
+	for _, keyword := range transactionKeywords {
+		if strings.Contains(lower, keyword) {
+			return SMTypeTransactionClass
+		}
+	}
+
+	// Default to financial institution for unknown types
+	return SMTypeFinancialInstitution
+}
+
+func cleanText(s string) string {
+	// Remove extra whitespace and newlines
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\t", " ")
+	// Collapse multiple spaces
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return s
+}

--- a/pkg/sources/fincen_311/reader_test.go
+++ b/pkg/sources/fincen_311/reader_test.go
@@ -1,0 +1,178 @@
+// Copyright The Moov Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fincen_311
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyEntityType(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected SMType
+	}{
+		{"ABLV Bank", SMTypeFinancialInstitution},
+		{"FBME Bank Ltd.", SMTypeFinancialInstitution},
+		{"Banca Privada d'Andorra", SMTypeFinancialInstitution},
+		{"Bitzlato Limited", SMTypeFinancialInstitution},
+		{"Liberty Reserve S.A.", SMTypeFinancialInstitution},
+		{"Casa de Cambio Puebla", SMTypeFinancialInstitution},
+
+		{"Islamic Republic of Iran", SMTypeJurisdiction},
+		{"Democratic People's Republic of Korea", SMTypeJurisdiction},
+		{"Burma", SMTypeJurisdiction},
+		{"Nauru", SMTypeJurisdiction},
+
+		{"Convertible Virtual Currency Mixing", SMTypeTransactionClass},
+		{"Class of Transactions", SMTypeTransactionClass},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyEntityType(tc.name)
+			require.Equal(t, tc.expected, result, "entity: %s", tc.name)
+		})
+	}
+}
+
+func TestCleanText(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"  ABLV Bank  ", "ABLV Bank"},
+		{"ABLV\n\nBank", "ABLV Bank"},
+		{"ABLV\t\tBank", "ABLV Bank"},
+		{"  Multiple   Spaces  ", "Multiple Spaces"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			result := cleanText(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseHTMLContents(t *testing.T) {
+	sampleHTML := `
+<!DOCTYPE html>
+<html>
+<body>
+<table>
+	<thead>
+		<tr>
+			<th>Entity Name</th>
+			<th>Finding</th>
+			<th>NPRM</th>
+			<th>Final Rule</th>
+			<th>Rescinded</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>ABLV Bank</td>
+			<td><a href="/sites/default/files/finding.pdf">02/13/2018</a></td>
+			<td><a href="/sites/default/files/nprm.pdf">02/16/2018</a></td>
+			<td><a href="/sites/default/files/final.pdf">06/25/2018</a></td>
+			<td>---</td>
+		</tr>
+		<tr>
+			<td>Islamic Republic of Iran</td>
+			<td><a href="/iran/finding.pdf">11/21/2011</a></td>
+			<td>---</td>
+			<td><a href="/iran/final.pdf">01/01/2012</a></td>
+			<td>---</td>
+		</tr>
+		<tr>
+			<td>Bitzlato Limited</td>
+			<td><a href="/bitzlato/finding.pdf">01/18/2023</a></td>
+			<td>---</td>
+			<td><a href="/bitzlato/final.pdf">05/01/2023</a></td>
+			<td><a href="/bitzlato/rescind.pdf">12/01/2024</a></td>
+		</tr>
+	</tbody>
+</table>
+</body>
+</html>`
+
+	reader := &testReadCloser{Reader: strings.NewReader(sampleHTML)}
+	data, err := parseHTMLContents(reader)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Len(t, data.SpecialMeasures, 3)
+	require.NotEmpty(t, data.ListHash)
+
+	// Check first entity (ABLV Bank)
+	ablv := data.SpecialMeasures[0]
+	require.Equal(t, "ABLV Bank", ablv.EntityName)
+	require.Equal(t, SMTypeFinancialInstitution, ablv.EntityType)
+	require.Contains(t, ablv.FindingURL, "finding.pdf")
+	require.Equal(t, "02/13/2018", ablv.FindingDate)
+	require.Contains(t, ablv.FinalRuleURL, "final.pdf")
+	require.False(t, ablv.IsRescinded)
+
+	// Check second entity (Iran - jurisdiction)
+	iran := data.SpecialMeasures[1]
+	require.Equal(t, "Islamic Republic of Iran", iran.EntityName)
+	require.Equal(t, SMTypeJurisdiction, iran.EntityType)
+	require.False(t, iran.IsRescinded)
+
+	// Check third entity (Bitzlato - rescinded)
+	bitzlato := data.SpecialMeasures[2]
+	require.Equal(t, "Bitzlato Limited", bitzlato.EntityName)
+	require.Equal(t, SMTypeFinancialInstitution, bitzlato.EntityType)
+	require.True(t, bitzlato.IsRescinded)
+	require.Contains(t, bitzlato.RescindedURL, "rescind.pdf")
+}
+
+func TestParseHTMLContents_NoTable(t *testing.T) {
+	sampleHTML := `
+<!DOCTYPE html>
+<html>
+<body>
+<p>No table here</p>
+</body>
+</html>`
+
+	reader := &testReadCloser{Reader: strings.NewReader(sampleHTML)}
+	_, err := parseHTMLContents(reader)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no table rows found")
+}
+
+func TestParseHTMLContents_EmptyTable(t *testing.T) {
+	sampleHTML := `
+<!DOCTYPE html>
+<html>
+<body>
+<table>
+	<thead>
+		<tr>
+			<th>Entity Name</th>
+		</tr>
+	</thead>
+	<tbody>
+	</tbody>
+</table>
+</body>
+</html>`
+
+	reader := &testReadCloser{Reader: strings.NewReader(sampleHTML)}
+	_, err := parseHTMLContents(reader)
+	require.Error(t, err)
+}
+
+// testReadCloser wraps a Reader to implement ReadCloser
+type testReadCloser struct {
+	io.Reader
+}
+
+func (t *testReadCloser) Close() error {
+	return nil
+}


### PR DESCRIPTION
Add support for US FinCEN Section 311 and 9714 Special Measures as a new sanctions data source. This list contains financial institutions, jurisdictions, and transaction classes subject to special measures.

Closes #646