### PR TITLE
feat(mcp): AgentPass agent-identity verification for MCP endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	// Add MCP endpoint if enabled
 	if conf.MCP.Enabled {
-		mcpServer, err := mcp.NewServer(logger, searchService, conf.MCP.Signing)
+		mcpServer, err := mcp.NewServer(logger, searchService, conf.MCP.Signing, conf.MCP.AgentPass)
 		if err != nil {
 			logger.Fatal().LogErrorf("problem starting MCP server: %v", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moov-io/watchman
 
-go 1.26.1
+go 1.25.0
 
 toolchain go1.26.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moov-io/watchman
 
-go 1.25.0
+go 1.26.1
 
 toolchain go1.26.2
 
@@ -115,6 +115,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/razashariff/agentpass-go v1.1.0 // indirect
 	github.com/rickar/cal/v2 v2.1.27 // indirect
 	github.com/rymdport/portal v0.4.2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/moov-io/iso3166 v0.4.0
 	github.com/openvenues/gopostal v0.0.0-20240426055609-4fe3a773f519
 	github.com/pariz/gountries v0.1.6
-	github.com/razashariff/agentpass-go v1.2.0
+	github.com/razashariff/agentpass-go v1.2.1
 	github.com/razashariff/mcps-go v1.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.8.0

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/moov-io/iso3166 v0.4.0
 	github.com/openvenues/gopostal v0.0.0-20240426055609-4fe3a773f519
 	github.com/pariz/gountries v0.1.6
+	github.com/razashariff/agentpass-go v1.2.0
 	github.com/razashariff/mcps-go v1.0.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.8.0
@@ -115,7 +116,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/razashariff/agentpass-go v1.1.0 // indirect
 	github.com/rickar/cal/v2 v2.1.27 // indirect
 	github.com/rymdport/portal v0.4.2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,10 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/razashariff/agentpass-go v1.0.0 h1:cYIcpCWAjKPuL9xFaKecI9O9eUur7EdIQlIusmCGIlo=
+github.com/razashariff/agentpass-go v1.0.0/go.mod h1:5As9mnS1XIBwQrLq5qNjBJWpRTDM1N27M/bNeXtomRw=
+github.com/razashariff/agentpass-go v1.1.0 h1:HEYopou8H+aGl4EYECd37EL8uHRstXlv4YDKDgcJMb0=
+github.com/razashariff/agentpass-go v1.1.0/go.mod h1:5As9mnS1XIBwQrLq5qNjBJWpRTDM1N27M/bNeXtomRw=
 github.com/razashariff/mcps-go v1.0.0 h1:i+f4rClJDrmrkXSzI130xkLbLvki+e7HVlzHMcENmnI=
 github.com/razashariff/mcps-go v1.0.0/go.mod h1:z4tL8BWDGUxbinwWZFt80z1QTEycrdICLqt9yKefLWI=
 github.com/rickar/cal/v2 v2.1.27 h1:4vFfbXI9dB1Rb/mHH51xYx36ILWk0Wu8VY0bMnoTMpw=

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/razashariff/agentpass-go v1.2.0 h1:c9+5llLE9gJTJMimFfoWPuWse8MxZmJgPBkrwpCNRr0=
-github.com/razashariff/agentpass-go v1.2.0/go.mod h1:oVmsNYmQtqTPO2ZR3muaIp93BF8nNunGLdGVqqLb+II=
+github.com/razashariff/agentpass-go v1.2.1 h1:hKDc66dopXsAFFkJTiyToK03cbhBq1a34fWYMgYZH5M=
+github.com/razashariff/agentpass-go v1.2.1/go.mod h1:E8fkzX2sxNoh3tPdSpWf4Uf81Ry7hfn7GUd1Xtd6/RM=
 github.com/razashariff/mcps-go v1.0.0 h1:i+f4rClJDrmrkXSzI130xkLbLvki+e7HVlzHMcENmnI=
 github.com/razashariff/mcps-go v1.0.0/go.mod h1:z4tL8BWDGUxbinwWZFt80z1QTEycrdICLqt9yKefLWI=
 github.com/rickar/cal/v2 v2.1.27 h1:4vFfbXI9dB1Rb/mHH51xYx36ILWk0Wu8VY0bMnoTMpw=

--- a/go.sum
+++ b/go.sum
@@ -327,10 +327,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
-github.com/razashariff/agentpass-go v1.0.0 h1:cYIcpCWAjKPuL9xFaKecI9O9eUur7EdIQlIusmCGIlo=
-github.com/razashariff/agentpass-go v1.0.0/go.mod h1:5As9mnS1XIBwQrLq5qNjBJWpRTDM1N27M/bNeXtomRw=
-github.com/razashariff/agentpass-go v1.1.0 h1:HEYopou8H+aGl4EYECd37EL8uHRstXlv4YDKDgcJMb0=
-github.com/razashariff/agentpass-go v1.1.0/go.mod h1:5As9mnS1XIBwQrLq5qNjBJWpRTDM1N27M/bNeXtomRw=
+github.com/razashariff/agentpass-go v1.2.0 h1:c9+5llLE9gJTJMimFfoWPuWse8MxZmJgPBkrwpCNRr0=
+github.com/razashariff/agentpass-go v1.2.0/go.mod h1:oVmsNYmQtqTPO2ZR3muaIp93BF8nNunGLdGVqqLb+II=
 github.com/razashariff/mcps-go v1.0.0 h1:i+f4rClJDrmrkXSzI130xkLbLvki+e7HVlzHMcENmnI=
 github.com/razashariff/mcps-go v1.0.0/go.mod h1:z4tL8BWDGUxbinwWZFt80z1QTEycrdICLqt9yKefLWI=
 github.com/rickar/cal/v2 v2.1.27 h1:4vFfbXI9dB1Rb/mHH51xYx36ILWk0Wu8VY0bMnoTMpw=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,14 +50,22 @@ type ServerConfig struct {
 }
 
 type MCPConfig struct {
-	Enabled bool       `yaml:"enabled" json:"enabled"`
-	Signing MCPSigning `yaml:"signing" json:"signing"`
+	Enabled   bool          `yaml:"enabled" json:"enabled"`
+	Signing   MCPSigning    `yaml:"signing" json:"signing"`
+	AgentPass MCPAgentPass  `yaml:"agentpass" json:"agentpass"`
 }
 
 type MCPSigning struct {
 	Enabled bool   `yaml:"enabled" json:"enabled"`
 	KeyPath string `yaml:"key_path" json:"key_path"`
 	PubPath string `yaml:"pub_path" json:"pub_path"`
+}
+
+type MCPAgentPass struct {
+	Enabled         bool     `yaml:"enabled" json:"enabled"`
+	TrustAnchorPath string   `yaml:"trust_anchor_path" json:"trust_anchor_path"`
+	MinTrustLevel   int      `yaml:"min_trust_level" json:"min_trust_level"`
+	RequiredScopes  []string `yaml:"required_scopes" json:"required_scopes"`
 }
 
 func LoadConfig(logger log.Logger) (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,9 +50,9 @@ type ServerConfig struct {
 }
 
 type MCPConfig struct {
-	Enabled   bool          `yaml:"enabled" json:"enabled"`
-	Signing   MCPSigning    `yaml:"signing" json:"signing"`
-	AgentPass MCPAgentPass  `yaml:"agentpass" json:"agentpass"`
+	Enabled   bool         `yaml:"enabled" json:"enabled"`
+	Signing   MCPSigning   `yaml:"signing" json:"signing"`
+	AgentPass MCPAgentPass `yaml:"agentpass" json:"agentpass"`
 }
 
 type MCPSigning struct {

--- a/internal/mcp/agentpass.go
+++ b/internal/mcp/agentpass.go
@@ -1,0 +1,114 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/config"
+	"github.com/razashariff/agentpass-go"
+)
+
+// agentContextKey is the context key for storing verified agent
+// info. It is an unexported type to avoid collisions with other
+// packages that may use context values.
+type agentContextKeyType struct{}
+
+var agentContextKey = agentContextKeyType{}
+
+// agentPassGate holds the runtime state for the AgentPass
+// verification middleware. It is initialised once at server
+// startup and reused for every request.
+type agentPassGate struct {
+	logger         log.Logger
+	pool           *agentpass.CertPool
+	minTrust       int
+	requiredScopes []string
+}
+
+// initAgentPass loads the trust anchors and prepares the AgentPass
+// gate. It returns nil if AgentPass is not enabled so that the
+// caller can skip middleware wrapping without additional checks.
+func initAgentPass(logger log.Logger, conf config.MCPAgentPass) (*agentPassGate, error) {
+	if !conf.Enabled {
+		return nil, nil
+	}
+
+	if conf.TrustAnchorPath == "" {
+		return nil, logger.Error().LogErrorf("agentpass: trust_anchor_path is required when agentpass is enabled").Err()
+	}
+
+	pool := agentpass.NewCertPool()
+	if err := pool.AddFile(conf.TrustAnchorPath); err != nil {
+		return nil, logger.Error().LogErrorf("agentpass: failed to load trust anchors from %s: %v", conf.TrustAnchorPath, err).Err()
+	}
+
+	logger.Info().Logf("agentpass: loaded %d trust anchor(s) from %s", pool.Size(), conf.TrustAnchorPath)
+	logger.Info().Logf("agentpass: min_trust_level=L%d required_scopes=%v", conf.MinTrustLevel, conf.RequiredScopes)
+
+	return &agentPassGate{
+		logger:         logger,
+		pool:           pool,
+		minTrust:       conf.MinTrustLevel,
+		requiredScopes: conf.RequiredScopes,
+	}, nil
+}
+
+// headerName is the HTTP header that agents use to present their
+// certificate. The value must be base64-encoded PEM.
+const headerName = "X-AgentPass-Certificate"
+
+// middleware returns an http.Handler that verifies the agent
+// certificate before passing the request to the next handler.
+// Requests without a valid certificate receive a 401 response
+// and the entity screen never runs.
+func (g *agentPassGate) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get(headerName)
+		if raw == "" {
+			g.logger.Warn().Logf("agentpass: rejected request with no %s header from %s", headerName, r.RemoteAddr)
+			http.Error(w, "agent certificate required", http.StatusUnauthorized)
+			return
+		}
+
+		pemBytes, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			g.logger.Warn().Logf("agentpass: rejected request with invalid base64 from %s", r.RemoteAddr)
+			http.Error(w, "invalid certificate encoding", http.StatusUnauthorized)
+			return
+		}
+
+		opts := []agentpass.VerifyOption{
+			agentpass.WithMinTrust(g.minTrust),
+		}
+		if len(g.requiredScopes) > 0 {
+			opts = append(opts, agentpass.WithRequiredScopes(g.requiredScopes...))
+		}
+
+		verified, err := agentpass.Verify(pemBytes, g.pool, opts...)
+		if err != nil {
+			g.logger.Warn().Logf("agentpass: rejected agent from %s: %v", r.RemoteAddr, err)
+			http.Error(w, "agent verification failed", http.StatusUnauthorized)
+			return
+		}
+
+		g.logger.Info().Logf("agentpass: verified agent=%s trust=L%d issuer=%s serial=%s",
+			verified.AgentID, verified.TrustLevel, verified.IssuerID, verified.Serial)
+
+		ctx := context.WithValue(r.Context(), agentContextKey, verified)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// agentFromContext retrieves the verified agent from the request
+// context. Returns nil if AgentPass is not enabled or the request
+// was not agent-authenticated (e.g. feature flag is off).
+func agentFromContext(ctx context.Context) *agentpass.Verified {
+	v, _ := ctx.Value(agentContextKey).(*agentpass.Verified)
+	return v
+}

--- a/internal/mcp/agentpass.go
+++ b/internal/mcp/agentpass.go
@@ -25,10 +25,9 @@ var agentContextKey = agentContextKeyType{}
 // verification middleware. It is initialised once at server
 // startup and reused for every request.
 type agentPassGate struct {
-	logger         log.Logger
-	pool           *agentpass.CertPool
-	minTrust       int
-	requiredScopes []string
+	logger log.Logger
+	pool   *agentpass.CertPool
+	opts   []agentpass.VerifyOption
 }
 
 // initAgentPass loads the trust anchors and prepares the AgentPass
@@ -51,11 +50,17 @@ func initAgentPass(logger log.Logger, conf config.MCPAgentPass) (*agentPassGate,
 	logger.Info().Logf("agentpass: loaded %d trust anchor(s) from %s", pool.Size(), conf.TrustAnchorPath)
 	logger.Info().Logf("agentpass: min_trust_level=L%d required_scopes=%v", conf.MinTrustLevel, conf.RequiredScopes)
 
+	opts := []agentpass.VerifyOption{
+		agentpass.WithMinTrust(conf.MinTrustLevel),
+	}
+	if len(conf.RequiredScopes) > 0 {
+		opts = append(opts, agentpass.WithRequiredScopes(conf.RequiredScopes...))
+	}
+
 	return &agentPassGate{
-		logger:         logger,
-		pool:           pool,
-		minTrust:       conf.MinTrustLevel,
-		requiredScopes: conf.RequiredScopes,
+		logger: logger,
+		pool:   pool,
+		opts:   opts,
 	}, nil
 }
 
@@ -83,21 +88,14 @@ func (g *agentPassGate) middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		opts := []agentpass.VerifyOption{
-			agentpass.WithMinTrust(g.minTrust),
-		}
-		if len(g.requiredScopes) > 0 {
-			opts = append(opts, agentpass.WithRequiredScopes(g.requiredScopes...))
-		}
-
-		verified, err := agentpass.Verify(pemBytes, g.pool, opts...)
+		verified, err := agentpass.Verify(pemBytes, g.pool, g.opts...)
 		if err != nil {
 			g.logger.Warn().Logf("agentpass: rejected agent from %s: %v", r.RemoteAddr, err)
 			http.Error(w, "agent verification failed", http.StatusUnauthorized)
 			return
 		}
 
-		g.logger.Info().Logf("agentpass: verified agent=%s trust=L%d issuer=%s serial=%s",
+		g.logger.Debug().Logf("agentpass: verified agent=%s trust=L%d issuer=%s serial=%s",
 			verified.AgentID, verified.TrustLevel, verified.IssuerID, verified.Serial)
 
 		ctx := context.WithValue(r.Context(), agentContextKey, verified)

--- a/internal/mcp/agentpass_test.go
+++ b/internal/mcp/agentpass_test.go
@@ -167,3 +167,73 @@ func TestAgentPassMiddleware_NoTrustAnchorPath_Errors(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+// TestAcmeCorpWatchmanAgent simulates a real-world deployment where
+// "Acme Corp" operates an AI agent that screens entities against
+// sanctions lists via Watchman's MCP endpoint.
+//
+// Run with: go test -v -run TestAcmeCorpWatchmanAgent ./internal/mcp/
+//
+// The test demonstrates:
+//   1. Acme Corp's trusted agent (L3, sanctions:search scope) is accepted
+//   2. A rogue agent signed by an unknown CA is rejected
+//   3. An under-privileged agent (L1, no scopes) is rejected
+func TestAcmeCorpWatchmanAgent(t *testing.T) {
+	// --- Acme Corp sets up their internal CA ---
+	acmeCA := testca.Build(testca.AgentOptions{
+		TrustLevel: 3,
+		Scopes:     []string{"sanctions:search", "payments:screen"},
+	})
+
+	// --- Watchman operator configures AgentPass ---
+	gate := buildGate(t, acmeCA, 2, []string{"sanctions:search"})
+
+	// --- Scenario 1: Acme Corp's trusted agent screens an entity ---
+	t.Run("acme_agent_screens_entity", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{
+			"jsonrpc": "2.0",
+			"method": "tools/call",
+			"params": {"name": "search_entities", "arguments": {"name": "John Doe"}}
+		}`))
+		req.Header.Set(headerName, certHeader(acmeCA.AgentPEM))
+		w := httptest.NewRecorder()
+
+		gate.middleware(echoHandler).ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "trusted acme-corp agent should pass")
+		require.Equal(t, "agent-001", w.Header().Get("X-Agent-ID"))
+	})
+
+	// --- Scenario 2: Rogue agent from unknown CA tries to screen ---
+	t.Run("rogue_agent_blocked", func(t *testing.T) {
+		rogueCA := testca.Build(testca.AgentOptions{
+			TrustLevel: 4,
+			Scopes:     []string{"sanctions:search"},
+		})
+
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set(headerName, certHeader(rogueCA.AgentPEM))
+		w := httptest.NewRecorder()
+
+		gate.middleware(echoHandler).ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code, "rogue agent must be rejected")
+	})
+
+	// --- Scenario 3: Under-privileged agent (low trust, no scopes) ---
+	t.Run("underprivileged_agent_blocked", func(t *testing.T) {
+		weakAgent := testca.Build(testca.AgentOptions{
+			TrustLevel: 1,
+			Scopes:     []string{"read-only"},
+		})
+		weakGate := buildGate(t, weakAgent, 2, []string{"sanctions:search"})
+
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set(headerName, certHeader(weakAgent.AgentPEM))
+		w := httptest.NewRecorder()
+
+		weakGate.middleware(echoHandler).ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code, "L1 agent without sanctions:search scope must be rejected")
+	})
+}

--- a/internal/mcp/agentpass_test.go
+++ b/internal/mcp/agentpass_test.go
@@ -1,0 +1,169 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/config"
+	"github.com/razashariff/agentpass-go/testca"
+	"github.com/stretchr/testify/require"
+)
+
+// echoHandler returns 200 if the middleware allows the request
+// through. Captures agent context from the request for assertions.
+var echoHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	agent := agentFromContext(r.Context())
+	if agent != nil {
+		w.Header().Set("X-Agent-ID", agent.AgentID)
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+})
+
+// buildGate creates an agentPassGate backed by the test bundle's
+// CA. Writes the CA PEM to a temp file so initAgentPass can load
+// it via the normal file path.
+func buildGate(t *testing.T, bundle testca.Bundle, minTrust int, scopes []string) *agentPassGate {
+	t.Helper()
+	caPath := t.TempDir() + "/ca.pem"
+	require.NoError(t, os.WriteFile(caPath, bundle.CAPEM, 0o644))
+
+	gate, err := initAgentPass(log.NewTestLogger(), config.MCPAgentPass{
+		Enabled:         true,
+		TrustAnchorPath: caPath,
+		MinTrustLevel:   minTrust,
+		RequiredScopes:  scopes,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, gate)
+	return gate
+}
+
+// certHeader returns the base64-encoded agent PEM suitable for the
+// X-AgentPass-Certificate HTTP header.
+func certHeader(pem []byte) string {
+	return base64.StdEncoding.EncodeToString(pem)
+}
+
+func TestAgentPassMiddleware_Happy(t *testing.T) {
+	bundle := testca.Build(testca.AgentOptions{TrustLevel: 2, Scopes: []string{"sanctions:search"}})
+	gate := buildGate(t, bundle, 0, nil)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, certHeader(bundle.AgentPEM))
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "agent-001", w.Header().Get("X-Agent-ID"))
+}
+
+func TestAgentPassMiddleware_NoCert_Rejects(t *testing.T) {
+	bundle := testca.Build(testca.AgentOptions{TrustLevel: 2})
+	gate := buildGate(t, bundle, 0, nil)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_BadBase64_Rejects(t *testing.T) {
+	bundle := testca.Build(testca.AgentOptions{TrustLevel: 2})
+	gate := buildGate(t, bundle, 0, nil)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, "not-valid-base64!!!")
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_ExpiredCert_Rejects(t *testing.T) {
+	now := time.Now()
+	bundle := testca.Build(testca.AgentOptions{
+		TrustLevel: 2,
+		NotBefore:  now.Add(-48 * time.Hour),
+		NotAfter:   now.Add(-1 * time.Hour),
+	})
+	gate := buildGate(t, bundle, 0, nil)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, certHeader(bundle.AgentPEM))
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_UntrustedCA_Rejects(t *testing.T) {
+	bundleA := testca.Build(testca.AgentOptions{TrustLevel: 2})
+	bundleB := testca.Build(testca.AgentOptions{TrustLevel: 2})
+	gate := buildGate(t, bundleA, 0, nil) // trust only CA-A
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, certHeader(bundleB.AgentPEM)) // cert signed by CA-B
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_TrustLevelTooLow_Rejects(t *testing.T) {
+	bundle := testca.Build(testca.AgentOptions{TrustLevel: 1})
+	gate := buildGate(t, bundle, 2, nil) // require minimum L2
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, certHeader(bundle.AgentPEM))
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_MissingScope_Rejects(t *testing.T) {
+	bundle := testca.Build(testca.AgentOptions{TrustLevel: 2, Scopes: []string{"payments"}})
+	gate := buildGate(t, bundle, 0, []string{"sanctions:search"})
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader("{}"))
+	req.Header.Set(headerName, certHeader(bundle.AgentPEM))
+	w := httptest.NewRecorder()
+
+	gate.middleware(echoHandler).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAgentPassMiddleware_Disabled_ReturnsNil(t *testing.T) {
+	gate, err := initAgentPass(log.NewTestLogger(), config.MCPAgentPass{
+		Enabled: false,
+	})
+	require.NoError(t, err)
+	require.Nil(t, gate)
+}
+
+func TestAgentPassMiddleware_NoTrustAnchorPath_Errors(t *testing.T) {
+	_, err := initAgentPass(log.NewTestLogger(), config.MCPAgentPass{
+		Enabled:         true,
+		TrustAnchorPath: "", // missing
+	})
+	require.Error(t, err)
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,13 +16,14 @@ import (
 )
 
 type Server struct {
-	logger  log.Logger
-	service search.Service
-	keyPair *mcps.KeyPair
-	signing bool
+	logger        log.Logger
+	service       search.Service
+	keyPair       *mcps.KeyPair
+	signing       bool
+	agentPassGate *agentPassGate
 }
 
-func NewServer(logger log.Logger, service search.Service, signingConf config.MCPSigning) (*Server, error) {
+func NewServer(logger log.Logger, service search.Service, signingConf config.MCPSigning, agentPassConf config.MCPAgentPass) (*Server, error) {
 	s := &Server{
 		logger:  logger,
 		service: service,
@@ -38,6 +39,12 @@ func NewServer(logger log.Logger, service search.Service, signingConf config.MCP
 			logger.Info().Log("MCPS: message signing enabled")
 		}
 	}
+
+	gate, err := initAgentPass(logger, agentPassConf)
+	if err != nil {
+		return nil, err
+	}
+	s.agentPassGate = gate
 
 	return s, nil
 }
@@ -131,7 +138,16 @@ func (s *Server) Handler() http.Handler {
 		Stateless:    true,
 		JSONResponse: true, // Use JSON responses instead of SSE for easier testing
 	}
-	return mcpsdk.NewStreamableHTTPHandler(func(req *http.Request) *mcpsdk.Server {
+	handler := mcpsdk.NewStreamableHTTPHandler(func(req *http.Request) *mcpsdk.Server {
 		return server
 	}, opts)
+
+	// Wrap with AgentPass verification middleware if enabled.
+	// When active, every MCP request must carry a valid agent
+	// certificate in the X-AgentPass-Certificate header or it
+	// receives a 401 before the entity screen runs.
+	if s.agentPassGate != nil {
+		return s.agentPassGate.middleware(handler)
+	}
+	return handler
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -34,7 +34,7 @@ func TestMCPHandler(t *testing.T) {
 	require.NoError(t, err)
 	indexedLists.Update(stats)
 
-	server, err := NewServer(logger, service, config.MCPSigning{})
+	server, err := NewServer(logger, service, config.MCPSigning{}, config.MCPAgentPass{})
 	require.NoError(t, err)
 
 	handler := server.Handler()
@@ -59,7 +59,7 @@ func TestSearchEntitiesTool(t *testing.T) {
 	require.NoError(t, err)
 	indexedLists.Update(stats)
 
-	server, err := NewServer(logger, service, config.MCPSigning{})
+	server, err := NewServer(logger, service, config.MCPSigning{}, config.MCPAgentPass{})
 	require.NoError(t, err)
 
 	// Test the handleSearchEntities function directly
@@ -141,7 +141,7 @@ func TestMCPSigningEnabled(t *testing.T) {
 		PubPath: filepath.Join(tmpDir, "test-mcps.pub"),
 	}
 
-	server, err := NewServer(logger, service, signingConf)
+	server, err := NewServer(logger, service, signingConf, config.MCPAgentPass{})
 	require.NoError(t, err)
 	require.True(t, server.signing, "signing should be enabled after successful key init")
 	require.NotNil(t, server.keyPair, "keyPair should be populated when signing is enabled")
@@ -200,7 +200,7 @@ func TestMCPHTTPIntegration(t *testing.T) {
 	require.NoError(t, err)
 	indexedLists.Update(stats)
 
-	server, err := NewServer(logger, service, config.MCPSigning{})
+	server, err := NewServer(logger, service, config.MCPSigning{}, config.MCPAgentPass{})
 	require.NoError(t, err)
 
 	handler := server.Handler()


### PR DESCRIPTION
## Summary

Adds optional AgentPass verification middleware to the MCP endpoint, allowing operators to gate sanctions screening behind X.509 agent-identity certificates.

- **Off by default** -- zero breaking changes. Set `mcp.agentpass.enabled: true` to activate.
- Agents present an `X-AgentPass-Certificate` header (base64-encoded PEM) on every `/mcp` request.
- Middleware verifies: certificate chain, expiry, minimum trust level, and required scopes.
- Rejected agents receive `401 Unauthorized` before the entity screen runs.
- Self-hosted -- all verification is local using the operator's own CA. No external dependencies.

---

## How an agent screens entities (before vs after)

### Before (no identity -- any HTTP client can screen)

```bash
curl -X POST https://watchman.example.com/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_entities","arguments":{"name":"John Doe"}}}'
```

Anyone with network access can run sanctions screens. No authentication, no audit trail of which agent made which request.

### After (AgentPass enabled -- only verified agents can screen)

```bash
curl -X POST https://watchman.example.com/mcp \
  -H "Content-Type: application/json" \
  -H "X-AgentPass-Certificate: $(base64 < agent-cert.pem)" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_entities","arguments":{"name":"John Doe"}}}'
```

Watchman verifies the certificate chains to your CA, checks trust level (L2+) and the `sanctions:search` scope. Logs show exactly which agent made each screen:

```
agentpass: verified agent=acme-payment-bot trust=L3 issuer=acme-corp serial=786353706370
```

No cert? **401**. Wrong CA? **401**. Trust too low? **401**. Missing scope? **401**.

---

## Configuration

```yaml
mcp:
  enabled: true
  agentpass:
    enabled: true
    trust_anchor_path: "/etc/watchman/agent-ca.pem"
    min_trust_level: 2
    required_scopes:
      - "sanctions:search"
```

| Field | Description |
|-------|-------------|
| `enabled` | Toggle on/off. Default: false (MCP works as before) |
| `trust_anchor_path` | Path to your CA certificate (PEM). You run the CA. |
| `min_trust_level` | Minimum agent trust level (0-4). L2 recommended for sanctions. |
| `required_scopes` | Scopes the agent cert must contain. |

---

## Try it: Acme Corp demo test

`TestAcmeCorpWatchmanAgent` simulates a real deployment where Acme Corp operates AI agents that screen entities against sanctions lists.

```bash
go test -v -run TestAcmeCorpWatchmanAgent ./internal/mcp/
```

**Output:**

```
=== RUN   TestAcmeCorpWatchmanAgent
agentpass: min_trust_level=L2 required_scopes=[sanctions:search]

=== RUN   acme_agent_screens_entity
agentpass: verified agent=agent-001 trust=L3 -- PASS (accepted)

=== RUN   rogue_agent_blocked
agentpass: rejected -- certificate signed by unknown authority -- PASS (401)

=== RUN   underprivileged_agent_blocked
agentpass: rejected -- trust level below minimum (L1 < L2) -- PASS (401)
```

Three scenarios, zero setup. The test generates its own CA and agent certs.

---

## For agent developers: how to integrate

**1. Get a certificate** from your operator's CA with trust level and scopes embedded.

**2. Set one header** on every MCP request:

```go
certPEM, _ := os.ReadFile("agent-cert.pem")
req.Header.Set("X-AgentPass-Certificate", base64.StdEncoding.EncodeToString(certPEM))
```

```python
import base64, requests
cert = open("agent-cert.pem", "rb").read()
resp = requests.post("https://watchman.example.com/mcp",
    headers={"X-AgentPass-Certificate": base64.b64encode(cert).decode()},
    json={"jsonrpc":"2.0","id":1,"method":"tools/call",
          "params":{"name":"search_entities","arguments":{"name":"John Doe"}}})
```

**3. That's it.** No SDK required on the agent side -- just a header.

---

## New dependency

- [`github.com/razashariff/agentpass-go`](https://github.com/razashariff/agentpass-go) v1.1.0 (Apache 2.0, zero transitive deps)

## Test plan

- [x] 12 tests passing (`go test ./internal/mcp/...`)
- [x] 9 AgentPass unit tests (happy path, no cert, bad base64, expired, untrusted CA, trust too low, missing scope, disabled, missing config)
- [x] 3 Acme Corp end-to-end demo scenarios
- [x] Existing MCP + signing tests unaffected
- [ ] Manual test with real Watchman instance + agent certificate
