### PR TITLE
feat(mcp): stamp agent identity into search_entities responses

### DIFF
--- a/internal/mcp/mcp_search_entities.go
+++ b/internal/mcp/mcp_search_entities.go
@@ -1,3 +1,7 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
 package mcp
 
 import (
@@ -41,6 +45,27 @@ type SearchEntitiesRequest struct {
 
 	Limit    *int     `json:"limit,omitempty" jsonschema:"Maximum number of results to return (default 10)"`
 	MinMatch *float64 `json:"minMatch,omitempty" jsonschema:"Minimum match score threshold (default 0.0)"`
+
+	IncludeDetails *bool `json:"includeDetails,omitempty" jsonschema:"Include field-level match score breakdown per result (names, addresses, IDs, etc.)"`
+}
+
+// AgentContext carries the verified identity of the AI agent that made this search request.
+// Only present when the MCP server has AgentPass authentication enabled and the request
+// carried a valid X-AgentPass-Certificate header.
+type AgentContext struct {
+	AgentID    string `json:"agentId"`
+	TrustLevel int    `json:"trustLevel"`
+	IssuerID   string `json:"issuerId"`
+}
+
+// mcpSearchResponse is the envelope returned by the search_entities MCP tool.
+// Uses explicit fields instead of embedding pubsearch.SearchResponse to avoid inheriting
+// a custom UnmarshalJSON that would swallow SearchedAt and AgentContext during tests.
+type mcpSearchResponse struct {
+	Query        pubsearch.Entity[pubsearch.Value]           `json:"query"`
+	Entities     []pubsearch.SearchedEntity[pubsearch.Value] `json:"entities"`
+	AgentContext *AgentContext                               `json:"agentContext,omitempty"`
+	SearchedAt   int64                                       `json:"searchedAt"`
 }
 
 func (s *Server) HandleSearchEntities(ctx context.Context, req *mcp.CallToolRequest, args SearchEntitiesRequest) (*mcp.CallToolResult, any, error) {
@@ -69,7 +94,7 @@ func (s *Server) HandleSearchEntities(ctx context.Context, req *mcp.CallToolRequ
 	}
 
 	opts := search.SearchOpts{
-		Limit:    25,
+		Limit:    10,
 		MinMatch: 0.0,
 	}
 
@@ -78,6 +103,16 @@ func (s *Server) HandleSearchEntities(ctx context.Context, req *mcp.CallToolRequ
 	}
 	if args.MinMatch != nil {
 		opts.MinMatch = *args.MinMatch
+	}
+	if args.IncludeDetails != nil && *args.IncludeDetails {
+		opts.Debug = true
+	}
+
+	// Log agent identity so compliance audit trails can tie agent to search activity.
+	agent := agentFromContext(ctx)
+	if agent != nil {
+		s.logger.Info().Logf("mcp: search by agent=%s trust=L%d issuer=%s name=%q type=%s",
+			agent.AgentID, agent.TrustLevel, agent.IssuerID, args.Request.Name, args.Request.Type)
 	}
 
 	// Normalize the request
@@ -94,12 +129,23 @@ func (s *Server) HandleSearchEntities(ctx context.Context, req *mcp.CallToolRequ
 		entities = []pubsearch.SearchedEntity[pubsearch.Value]{}
 	}
 
-	response := pubsearch.SearchResponse{
-		Query:    searchReq,
-		Entities: entities,
+	resp := mcpSearchResponse{
+		Query:      searchReq,
+		Entities:   entities,
+		SearchedAt: time.Now().Unix(),
 	}
 
-	responseJSON, err := json.Marshal(response)
+	// Stamp verified agent identity into the response so that MCPS-signed
+	// envelopes carry cryptographic proof of who requested this search.
+	if agent != nil {
+		resp.AgentContext = &AgentContext{
+			AgentID:    agent.AgentID,
+			TrustLevel: agent.TrustLevel,
+			IssuerID:   agent.IssuerID,
+		}
+	}
+
+	responseJSON, err := json.Marshal(resp)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 	}

--- a/internal/mcp/mcp_search_entities_test.go
+++ b/internal/mcp/mcp_search_entities_test.go
@@ -1,0 +1,203 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/config"
+	"github.com/moov-io/watchman/internal/index"
+	"github.com/moov-io/watchman/internal/ofactest"
+	"github.com/moov-io/watchman/internal/search"
+	pubsearch "github.com/moov-io/watchman/pkg/search"
+	"github.com/razashariff/agentpass-go"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	logger := log.NewTestLogger()
+	indexedLists := index.NewLists(nil)
+	searchConfig := search.DefaultConfig()
+	svc, err := search.NewService(logger, searchConfig, nil, indexedLists)
+	require.NoError(t, err)
+
+	dl := ofactest.GetDownloader(t)
+	stats, err := dl.RefreshAll(context.Background())
+	require.NoError(t, err)
+	indexedLists.Update(stats)
+
+	srv, err := NewServer(logger, svc, config.MCPConfig{})
+	require.NoError(t, err)
+	return srv
+}
+
+func contextWithAgent(ctx context.Context, agentID string, trustLevel int, issuerID string) context.Context {
+	v := &agentpass.Verified{
+		Agent: agentpass.Agent{
+			AgentID:    agentID,
+			TrustLevel: trustLevel,
+			IssuerID:   issuerID,
+		},
+	}
+	return context.WithValue(ctx, agentContextKey, v)
+}
+
+func TestSearchEntities_SearchedAtAlwaysPresent(t *testing.T) {
+	srv := newTestServer(t)
+
+	result, _, err := srv.HandleSearchEntities(context.Background(), &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request: SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	var resp mcpSearchResponse
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	require.Greater(t, resp.SearchedAt, int64(0), "searchedAt should be a non-zero unix timestamp")
+}
+
+func TestSearchEntities_NoAgentContext(t *testing.T) {
+	srv := newTestServer(t)
+
+	result, _, err := srv.HandleSearchEntities(context.Background(), &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request: SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+	})
+	require.NoError(t, err)
+
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var resp mcpSearchResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	require.Nil(t, resp.AgentContext, "agentContext should be absent when no agent is authenticated")
+}
+
+func TestSearchEntities_AgentContextInResponse(t *testing.T) {
+	srv := newTestServer(t)
+
+	ctx := contextWithAgent(context.Background(), "acme-agent-001", 2, "acme-corp")
+
+	result, _, err := srv.HandleSearchEntities(ctx, &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request: SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+	})
+	require.NoError(t, err)
+
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var resp mcpSearchResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	require.NotNil(t, resp.AgentContext, "agentContext must be present when agent is authenticated")
+	require.Equal(t, "acme-agent-001", resp.AgentContext.AgentID)
+	require.Equal(t, 2, resp.AgentContext.TrustLevel)
+	require.Equal(t, "acme-corp", resp.AgentContext.IssuerID)
+}
+
+func TestSearchEntities_AgentContextInSignedResponse(t *testing.T) {
+	logger := log.NewTestLogger()
+	indexedLists := index.NewLists(nil)
+	searchConfig := search.DefaultConfig()
+	svc, err := search.NewService(logger, searchConfig, nil, indexedLists)
+	require.NoError(t, err)
+
+	dl := ofactest.GetDownloader(t)
+	stats, err := dl.RefreshAll(context.Background())
+	require.NoError(t, err)
+	indexedLists.Update(stats)
+
+	tmpDir := t.TempDir()
+	srv, err := NewServer(logger, svc, config.MCPConfig{
+		Signing: config.MCPSigning{
+			Enabled: true,
+			KeyPath: tmpDir + "/test.key",
+			PubPath: tmpDir + "/test.pub",
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := contextWithAgent(context.Background(), "signing-agent-007", 3, "partner-ca")
+
+	result, _, err := srv.HandleSearchEntities(ctx, &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request: SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	// MCPS-signed envelope wraps the payload — unwrap and verify agent context is inside.
+	// mcps-go SignedMessage has: mcps_version, passport_id, nonce, timestamp, signature, message.
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var envelope map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+
+	_, hasSignature := envelope["signature"]
+	require.True(t, hasSignature, "response should be a signed envelope")
+
+	// The signed payload is in the "message" field.
+	message, ok := envelope["message"]
+	require.True(t, ok, "signed envelope must contain message field")
+
+	var inner mcpSearchResponse
+	require.NoError(t, json.Unmarshal(message, &inner))
+	require.NotNil(t, inner.AgentContext)
+	require.Equal(t, "signing-agent-007", inner.AgentContext.AgentID)
+	require.Equal(t, 3, inner.AgentContext.TrustLevel)
+}
+
+func TestSearchEntities_IncludeDetails_PopulatesScorePieces(t *testing.T) {
+	srv := newTestServer(t)
+
+	includeDetails := true
+	minMatch := 0.50
+
+	result, _, err := srv.HandleSearchEntities(context.Background(), &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request:        SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+		MinMatch:       &minMatch,
+		IncludeDetails: &includeDetails,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var resp mcpSearchResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	require.NotEmpty(t, resp.Entities, "expected at least one match for 'Logan'")
+
+	// When includeDetails=true, every returned entity must carry SimilarityScore pieces.
+	for _, entity := range resp.Entities {
+		require.NotEmpty(t, entity.Details.Pieces,
+			"entity %s/%s should have Details.Pieces when includeDetails=true",
+			entity.Source, entity.SourceID)
+	}
+}
+
+func TestSearchEntities_IncludeDetails_FalseOmitsPieces(t *testing.T) {
+	srv := newTestServer(t)
+
+	includeDetails := false
+	minMatch := 0.50
+
+	result, _, err := srv.HandleSearchEntities(context.Background(), &mcpsdk.CallToolRequest{}, SearchEntitiesRequest{
+		Request:        SearchEntityRequest{Name: "Logan", Type: pubsearch.EntityPerson},
+		MinMatch:       &minMatch,
+		IncludeDetails: &includeDetails,
+	})
+	require.NoError(t, err)
+
+	text := result.Content[0].(*mcpsdk.TextContent).Text
+	var resp mcpSearchResponse
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+	require.NotEmpty(t, resp.Entities)
+	for _, entity := range resp.Entities {
+		require.Empty(t, entity.Details.Pieces,
+			"Details.Pieces should be empty when includeDetails=false")
+	}
+}


### PR DESCRIPTION
Wire up agentFromContext (previously dead code) to log the requesting agent for audit trails and include AgentContext in the response envelope. Add includeDetails flag to expose field-level SimilarityScore breakdowns.