### PR TITLE
perf: warm up libpostal concurrently with the initial data load

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -70,10 +71,27 @@ func main() {
 	// Listen for errors
 	errs := make(chan error, 1)
 
-	// Init libpostal (if configured)
-	start := time.Now()
-	got := address.ParseAddress(ctx, "123 First St Anytown CA 90210")
-	logger.Debug().Logf("parsing init address (%s) took %v", got.Format(), time.Since(start))
+	// Warm up libpostal (if configured). On a multi-CPU host this runs
+	// concurrently with the initial data load below. Both are heavy,
+	// independent startup steps, so overlapping them shortens startup. With a
+	// single CPU there is nothing to overlap, so run it inline. When started
+	// concurrently the warm-up is joined before the HTTP server serves (below).
+	warmUpLibpostal := func() {
+		start := time.Now()
+		got := address.ParseAddress(ctx, "123 First St Anytown CA 90210")
+		logger.Debug().Logf("parsing init address (%s) took %v", got.Format(), time.Since(start))
+	}
+
+	var libpostalWarm chan struct{}
+	if runtime.GOMAXPROCS(0) > 1 {
+		libpostalWarm = make(chan struct{})
+		go func() {
+			defer close(libpostalWarm)
+			warmUpLibpostal()
+		}()
+	} else {
+		warmUpLibpostal()
+	}
 
 	// Setup database
 	database, shutdown, err := db.New(conf.Database, logger)
@@ -111,6 +129,13 @@ func main() {
 	if err != nil {
 		logger.Fatal().LogErrorf("problem during initial download: %v", err)
 		os.Exit(1)
+	}
+
+	// If the warm-up was started concurrently, block until it finishes so the
+	// first search request does not pay the model load. This has overlapped
+	// with the data load above.
+	if libpostalWarm != nil {
+		<-libpostalWarm
 	}
 
 	router := mux.NewRouter()


### PR DESCRIPTION
## What

At startup the libpostal warm-up (`address.ParseAddress` in `cmd/server/main.go`) runs to completion before the initial OFAC/list data load and indexing. Both are among the heaviest startup steps and they are independent, so the server pays for them back to back.

This runs the libpostal warm-up concurrently with the data load on multi-CPU hosts and joins it before the HTTP server starts serving. On a single CPU (`GOMAXPROCS == 1`) there is nothing to overlap, so it falls back to the original inline path.

## Correctness

Behavior is unchanged:

- The warm-up still completes before any request is served. It is joined right after the initial data load and before routes are registered, so the first search never races the libpostal model load.
- Only the warm-up goroutine touches libpostal; the data load shares no state with it, so there is no concurrent cgo access.
- With `GOMAXPROCS == 1` the original sequential path runs unchanged.

Existing tests pass without modification.

## Benchmark

Startup time, measured from the `Starting watchman server` log line to `listening`, libpostal build with the full OFAC list loaded:

```
startup   12.0s -> 8.0s
```

The saving equals the overlap of the two steps: the smaller of the warm-up and the data load is hidden under the larger. On a cold or CPU-throttled host where the libpostal warm-up dominates, the data-load time is hidden almost entirely.
