### PR TITLE
perf: skip stopword removal for OFAC person names

### DIFF
--- a/pkg/search/models.go
+++ b/pkg/search/models.go
@@ -289,9 +289,15 @@ type PreparedAddress struct {
 }
 
 func (e Entity[T]) Normalize() Entity[T] {
+	// Personal names are proper nouns whose "stopword-like" tokens ("al", "bin",
+	// "de", "van") are meaningful particles, so for people we skip stopword
+	// removal. That also avoids the whatlanggo language detection that stopword
+	// removal performs, which dominates index preparation cost. See nameFields.
+	isPerson := e.Person != nil
+
 	// Name
 	e.PreparedFields.Name = prepare.LowerAndRemovePunctuation(e.Name)
-	e.PreparedFields.NameFields = removeStopwords(e.PreparedFields.Name)
+	e.PreparedFields.NameFields = nameFields(e.PreparedFields.Name, isPerson)
 
 	// Entity Type
 	if e.Person != nil {
@@ -314,7 +320,7 @@ func (e Entity[T]) Normalize() Entity[T] {
 	if len(e.PreparedFields.AltNames) > 0 {
 		e.PreparedFields.AltNameFields = make([][]string, len(e.PreparedFields.AltNames))
 		for idx := range e.PreparedFields.AltNames {
-			e.PreparedFields.AltNameFields[idx] = removeStopwords(e.PreparedFields.AltNames[idx])
+			e.PreparedFields.AltNameFields[idx] = nameFields(e.PreparedFields.AltNames[idx], isPerson)
 		}
 	}
 
@@ -328,9 +334,20 @@ func (e Entity[T]) Normalize() Entity[T] {
 	return e
 }
 
-func removeStopwords(input string) []string {
+// nameFields splits a normalized name into its search tokens. For people it
+// skips stopword removal: personal names are proper nouns where "stopword-like"
+// tokens ("al", "bin", "de", "van") are meaningful particles, and the whatlanggo
+// language detection that stopword removal performs dominates index preparation.
+// Other entity types keep stopword removal, where tokens like
+// "the"/"company"/"limited" are noise. The input is already lowercased,
+// depunctuated and unicode-normalized by LowerAndRemovePunctuation, so the
+// person path needs no further cleanup.
+func nameFields(input string, isPerson bool) []string {
 	if input == "" {
 		return nil
+	}
+	if isPerson {
+		return strings.Fields(input)
 	}
 	return strings.Fields(prepare.RemoveStopwords(input))
 }

--- a/pkg/search/models_test.go
+++ b/pkg/search/models_test.go
@@ -175,6 +175,35 @@ func TestEntity_Normalize(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Person names keep "stopword-like" particles ("al", "abu") that
+			// stopword removal would otherwise strip; for people we skip it.
+			name: "person keeps name particles",
+			input: Entity[Value]{
+				Name: "Saddam Hussein al-Tikriti",
+				Type: EntityPerson,
+				Person: &Person{
+					Name:     "Saddam Hussein al-Tikriti",
+					AltNames: []string{"Abu Ali"},
+				},
+			},
+			expected: Entity[Value]{
+				Name: "Saddam Hussein al-Tikriti",
+				Type: "person",
+				Person: &Person{
+					Name:     "Saddam Hussein al-Tikriti",
+					AltNames: []string{"Abu Ali"},
+				},
+				PreparedFields: PreparedFields{
+					Name:       "saddam hussein al tikriti",
+					NameFields: []string{"saddam", "hussein", "al", "tikriti"},
+					AltNames:   []string{"abu ali"},
+					AltNameFields: [][]string{
+						{"abu", "ali"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What

`Entity.Normalize` runs stopword removal on every name and alt name when grouping SDNs into entities. Stopword removal calls `whatlanggo.Detect` for any token the trivial fast path cannot clear, and that language detection is the single heaviest step when the OFAC list is prepared at startup.

Personal names are proper nouns. The tokens stopword removal would drop from them (`al`, `bin`, `de`, `la`, `van`, `von`, ...) are name particles rather than noise, and they sit in the cross-language stopword union, so almost every person name falls through to `whatlanggo.Detect`. This skips stopword removal for person entities and tokenizes the name directly. The name is already lowercased, depunctuated and unicode-normalized by `LowerAndRemovePunctuation`, so no further cleanup is needed. Businesses, organizations, vessels and aircraft keep stopword removal, where tokens like `the`, `company` and `limited` are noise.

Entity type is set identically on indexed records and on search requests (individual SDNs and `type=person` queries both populate `Person`), so query and index names are tokenized the same way and matching is unaffected.

## Correctness

For person names without stopword-like tokens the output is identical to before; the trivial path already produced the same tokens. For names that contain particles those tokens are now kept rather than dropped, on both the index and the query side, so they still match each other. Existing `pkg/search`, `internal/prepare` and `pkg/sources/ofac` tests pass, and a `Normalize` test case covers the person path.

## Benchmark

Single core, current OFAC SDN data (~19k records), grouping SDNs into entities:

```
GroupIntoEntities   2.95s -> 2.37s   (-20%)
```

The remaining preparation time is dominated by `whatlanggo.Detect` on non-person entities and their aliases, which keep stopword removal.