### PR TITLE
feat(sources): integrate US State Terrorist Exclusion List (US TEL)

### DIFF
--- a/configs/config.default.yml
+++ b/configs/config.default.yml
@@ -22,7 +22,16 @@ Watchman:
 
     # Specify which lists to download and include in Watchman results
     # Examples: us_csl, us_ofac, us_non_sdn, us_fincen_311, uk_csl, eu_csl, un_csl
-    IncludedLists: []
+    IncludedLists: [
+      'us_csl',
+      'us_ofac',
+      'us_non_sdn',
+      'us_fincen_311',
+      'uk_csl',
+      'eu_csl',
+      'un_csl',
+      'us_tel',
+    ]
 
     # Source-list names for which download or parse errors are suppressed.
     # A failed list named here will log a warning but will not cause a refresh error.

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -14,3 +14,4 @@
   </rapi-doc>
 </body>
 </html>
+  

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -54,6 +54,7 @@ var knownDownloadableLists = []search.SourceList{
 	search.SourceUSNonSDN,
 	search.SourceUSFinCEN311,
 	search.SourceUNCSL,
+	search.SourceUSTEL,
 }
 
 func (dl *downloader) RefreshAll(ctx context.Context) (Stats, error) {
@@ -293,6 +294,26 @@ func (dl *downloader) RefreshAll(ctx context.Context) (Stats, error) {
 					return nil
 				}
 				return fmt.Errorf("loading UN CSL records: %w", err)
+			}
+			return nil
+		})
+	}
+
+	// US TEL Records
+	if slices.Contains(requestedLists, search.SourceUSTEL) {
+		listsLoaded = append(listsLoaded, search.SourceUSTEL)
+
+		producerWg.Add(1)
+		g.Go(func() error {
+			defer producerWg.Done()
+
+			err := loadUSTelRecords(ctx, logger, dl.conf, preparedLists)
+			if err != nil {
+				if slices.Contains(ignoredLists, search.SourceUSTEL) {
+					logger.Warn().Logf("ignoring error loading %s: %v", search.SourceUSTEL, err)
+					return nil
+				}
+				return fmt.Errorf("loading US TEL records: %w", err)
 			}
 			return nil
 		})

--- a/internal/download/download_us_tel.go
+++ b/internal/download/download_us_tel.go
@@ -1,0 +1,85 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package download
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/telemetry"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/moov-io/watchman/pkg/sources/us_tel"
+)
+
+func loadUSTelRecords(ctx context.Context, logger log.Logger, conf Config, responseCh chan preparedList) error {
+	ctx, span := telemetry.StartSpan(ctx, "load-us-tel-records")
+	defer span.End()
+
+	start := time.Now()
+
+	files, err := us_tel.DownloadUsTel(ctx, logger, initialDataDirectory(conf))
+	if err != nil {
+		return fmt.Errorf("US TEL download error: %w", err)
+	}
+
+	span.AddEvent("finished downloading")
+
+	if len(files) == 0 {
+		return fmt.Errorf("unexpected %d US TEL files found", len(files))
+	}
+
+	logger.Debug().Logf("finished US TEL download: %v", time.Since(start))
+	start = time.Now()
+
+	var entities []search.Entity[search.Value]
+	var hashData bytes.Buffer
+
+	for filename, fd := range files {
+		content, err := io.ReadAll(fd)
+		if closeErr := fd.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			return fmt.Errorf("reading US TEL %s: %w", filename, err)
+		}
+		hashData.Write(content)
+
+		// Parse from buffer
+		reader := us_tel.NewReader(bytes.NewReader(content))
+		err = reader.Read(func(record us_tel.TELRecord) {
+			entities = append(entities, record.ToEntity())
+		})
+		if err != nil {
+			return fmt.Errorf("parsing US TEL %s: %w", filename, err)
+		}
+	}
+
+	h := sha256.Sum256(hashData.Bytes())
+	listHash := hex.EncodeToString(h[:])
+
+	span.AddEvent("finished parsing")
+
+	logger.Debug().Logf("finished US TEL preparation: %d entities in %v", len(entities), time.Since(start))
+	span.AddEvent("finished US TEL preparation")
+
+	if len(entities) == 0 && conf.ErrorOnEmptyList {
+		return errors.New("no entities parsed from US TEL")
+	}
+
+	responseCh <- preparedList{
+		ListName: search.SourceUSTEL,
+		Entities: entities,
+		Hash:     listHash,
+	}
+
+	return nil
+}

--- a/internal/download/download_us_tel_test.go
+++ b/internal/download/download_us_tel_test.go
@@ -1,0 +1,48 @@
+package download_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloader_RefreshAll_USTel(t *testing.T) {
+	logger := log.NewTestLogger()
+	conf := download.Config{
+		InitialDataDirectory: filepath.Join("..", "..", "test", "testdata"),
+		ErrorOnEmptyList:     true,
+		IncludedLists: []search.SourceList{
+			search.SourceUSTEL,
+		},
+	}
+
+	dl, err := download.NewDownloader(logger, conf, nil)
+	require.NoError(t, err)
+	require.NotNil(t, dl)
+
+	stats, err := dl.RefreshAll(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+
+	// Verify entities were loaded
+	require.Greater(t, len(stats.Entities), 0, "expected at least some US TEL entities")
+
+	// Verify list tracking
+	name := string(search.SourceUSTEL)
+	require.Greater(t, stats.Lists[name], 0)
+	require.NotEmpty(t, stats.ListHashes[name], "expected list hash to be computed")
+
+	// Check a few entities
+	for _, entity := range stats.Entities {
+		require.Equal(t, search.SourceUSTEL, entity.Source, "entity should have US TEL source")
+		require.NotEmpty(t, entity.SourceID, "entity should have source ID")
+		require.NotEmpty(t, entity.Name, "entity should have name")
+		require.NotNil(t, entity.SourceData, "entity should have SourceData")
+	}
+}

--- a/pkg/search/models.go
+++ b/pkg/search/models.go
@@ -62,7 +62,7 @@ func (sl SourceList) IsRequestType() bool {
 var (
 	SourceAPIRequest SourceList = "api-request"
 	SourceMCPRequest SourceList = "mcp-request"
-
+	SourceUSTEL	  	  SourceList = "us_tel"
 	SourceEUCSL       SourceList = "eu_csl"
 	SourceUKCSL       SourceList = "uk_csl"
 	SourceUSCSL       SourceList = "us_csl"

--- a/pkg/sources/display/display.go
+++ b/pkg/sources/display/display.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moov-io/watchman/pkg/sources/csl_us"
 	"github.com/moov-io/watchman/pkg/sources/ofac"
 	"github.com/moov-io/watchman/pkg/sources/opensanctions"
+	"github.com/moov-io/watchman/pkg/sources/us_tel"
 )
 
 // DetailsURL returns a URL where you can view the entity on the source's website
@@ -26,6 +27,9 @@ func DetailsURL(entity search.Entity[search.Value]) string {
 
 	case search.SourceUSOFAC, search.SourceUSNonSDN:
 		return ofac.DetailsURL(entity.SourceID)
+
+	case search.SourceUSTEL:
+		return us_tel.DetailsURL(entity.SourceID)
 
 	case search.SourceAPIRequest, search.SourceMCPRequest:
 		// do nothing

--- a/pkg/sources/display/display_test.go
+++ b/pkg/sources/display/display_test.go
@@ -41,6 +41,13 @@ func TestDetailsURL(t *testing.T) {
 			Expected: "https://www.gov.uk/government/publications/the-uk-sanctions-list",
 		},
 		{
+			Entity: search.Entity[search.Value]{
+				Source:   search.SourceUSTEL,
+				SourceID: "TEL-12345",
+			},
+			Expected: "https://www.state.gov/terrorist-exclusion-list",
+		},
+		{
 			Entity:   apiRequest,
 			Expected: "/v2/search?altNames=BURTON+BURGESS&birthDate=1963-07-28&gov_passport=Belize%3AP0017003&gov_ssn=United+States%3A561-77-9011&name=Elvis+Angus+LOGAN+MOREY&type=person",
 		},

--- a/pkg/sources/us_tel/display.go
+++ b/pkg/sources/us_tel/display.go
@@ -1,0 +1,14 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package us_tel
+
+// DetailsURL returns the US State Terrorist Exclusion List page.
+//
+//	The US does not provide a unique URL for each entity,
+//
+// so we return the main
+func DetailsURL(sourceID string) string {
+	return "https://www.state.gov/terrorist-exclusion-list"
+}

--- a/pkg/sources/us_tel/download_us_tel.go
+++ b/pkg/sources/us_tel/download_us_tel.go
@@ -1,0 +1,31 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package us_tel
+
+import (
+	"fmt"
+	"context"
+	"io"
+	"os"
+	"encoding/json"
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/strx"
+	"github.com/moov-io/watchman/pkg/download"
+)
+
+var (
+	publicUSTelDownloadUrl = strx.Or(os.Getenv("US_TEL_URL"), "https://data.opensanctions.org/datasets/latest/us_state_terrorist_exclusion/targets.nested.json")
+)
+func DownloadUsTel(ctx context.Context, logger log.Logger, initialDir string) (map[string]io.ReadCloser, error) {
+	dl := download.New(logger, nil)
+
+	telNameAndSourceMap := make(map[string]string)
+	telNameAndSourceMap["us_tel.json"] = publicUSTelDownloadUrl
+	jsonBytes, _ := json.Marshal(telNameAndSourceMap)
+	
+	fmt.Println("Downloading US State Terrorist Exclusion List", string(jsonBytes))
+	return dl.GetFiles(ctx, initialDir, telNameAndSourceMap)
+
+}

--- a/pkg/sources/us_tel/download_us_tel_test.go
+++ b/pkg/sources/us_tel/download_us_tel_test.go
@@ -1,0 +1,105 @@
+package us_tel
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/base/log"
+)
+
+func TestUSTelDownload_initialDir(t *testing.T) {
+	dir, err := os.MkdirTemp("", "initial-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	mk := func(t *testing.T, name string, body string) {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+
+	mk(t, "us_tel.json", "file=us_tel.json")
+
+	file, err := DownloadUsTel(context.Background(), log.NewNopLogger(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(file) == 0 {
+		t.Fatal("no US TEL file")
+	}
+
+	for fn, fd := range file {
+		if strings.EqualFold("us_tel.json", filepath.Base(fn)) {
+			_, err := io.ReadAll(fd)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			t.Fatalf("unknown file: %v", file)
+		}
+	}
+}
+
+func TestUSTelDownload_fromURL(t *testing.T) {
+	// prepare temporary file with known content
+	f, err := os.CreateTemp("", "us_tel-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := "hello-us-tel"
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	defer os.Remove(f.Name())
+	orig := publicUSTelDownloadUrl
+	publicUSTelDownloadUrl = "file://" + f.Name()
+	defer func() { publicUSTelDownloadUrl = orig }()
+
+	os.Setenv("US_TEL_URL", "file://"+f.Name())
+	defer os.Unsetenv("US_TEL_URL")
+
+	files, err := DownloadUsTel(context.Background(), log.NewNopLogger(), "")
+	if err != nil {
+		t.Fatalf("expected download success, got %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected exactly 1 file, got %d", len(files))
+	}
+
+	for _, rc := range files {
+		buf, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(buf) != content {
+			t.Errorf("downloaded content mismatch: %q", string(buf))
+		}
+	}
+}
+
+func TestUSTelDownload_badURL(t *testing.T) {
+	orig := publicUSTelDownloadUrl
+	defer func() { publicUSTelDownloadUrl = orig }()
+
+	publicUSTelDownloadUrl = "file:///nonexistent/path"
+
+	files, err := DownloadUsTel(context.Background(), log.NewNopLogger(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(files) != 0 {
+		t.Errorf("expected 0 files returned on failure, got %d", len(files))
+	}
+}

--- a/pkg/sources/us_tel/mapper.go
+++ b/pkg/sources/us_tel/mapper.go
@@ -1,0 +1,103 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package us_tel
+
+import (
+	"strings"
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+func addPersonToEntity(name string, aliases []string, entity *search.Entity[search.Value]) {
+	if entity.Type != search.EntityPerson {
+		return
+	}
+
+	entity.Person = &search.Person{
+		Name: name,
+	}
+
+	for _, alias := range aliases {
+		entity.Person.AltNames = append(entity.Person.AltNames, alias)
+	}
+	
+	// FIX: Removed "return entity" since this function has no return type specified
+}
+
+func addBusinessToEntity(name string, aliases []string, entity *search.Entity[search.Value]) {
+	if entity.Type != search.EntityBusiness {
+		return
+	}
+
+	entity.Business = &search.Business{
+		Name: name,
+	}
+
+	for _, alias := range aliases {
+		entity.Business.AltNames = append(entity.Business.AltNames, alias)
+	}
+	
+	// FIX: Removed "return entity" since this function has no return type specified
+}
+
+func (r TELRecord) ToEntity() search.Entity[search.Value] {
+	name := r.primaryName()
+	aliases := r.altNames(name)
+
+	entity := search.Entity[search.Value]{
+		SourceID:   r.ID,
+		Name:       name,
+		Type:       entityTypeForSchema(r.Schema),
+		Source:     search.SourceUSTEL,
+		SourceData: r,
+	}
+
+	// FIX: Call them directly. The functions modify 'entity' in-place via its pointer memory address.
+	addPersonToEntity(name, aliases, &entity)
+	addBusinessToEntity(name, aliases, &entity)
+
+	return entity.Normalize()
+}
+
+func (r TELRecord) primaryName() string {
+	for _, name := range r.Properties.Name {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			return name
+		}
+	}
+
+	return strings.TrimSpace(r.Caption)
+}
+
+func (r TELRecord) altNames(primary string) []string {
+	seen := map[string]bool{}
+	alts := []string{}
+
+	primary = strings.TrimSpace(primary)
+	if primary != "" {
+		seen[primary] = true
+	}
+
+	for _, name := range r.Properties.Name {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+
+		alts = append(alts, name)
+		seen[name] = true
+	}
+
+	return alts
+}
+
+func entityTypeForSchema(schema string) search.EntityType {
+	switch strings.ToLower(strings.TrimSpace(schema)) {
+	case "person":
+		return search.EntityPerson
+	default:
+		return search.EntityBusiness
+	}
+}

--- a/pkg/sources/us_tel/mapper_test.go
+++ b/pkg/sources/us_tel/mapper_test.go
@@ -1,0 +1,139 @@
+// Copyright The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package us_tel
+
+import (
+	"testing"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+
+func TestTELRecord_ToEntity_LegalEntity(t *testing.T) {
+	r := TELRecord{
+		ID:      "NK-245arpDkLm74auKv2h9w3m",
+		Caption: "Japanese Red Army (JRA)",
+		Schema:  "LegalEntity",
+		Referents: []string{
+			"us-dos-terr-9905ea8331b9d183638112392c6d35b1b4bafada",
+			"us-dos-fto-078566d5306ffe94820da46e73a2311ec39f495c",
+		},
+		Datasets: []string{"us_state_terrorist_exclusion"},
+		Origin:   []string{"inferred"},
+		FirstSeen:  "2024-06-10T20:32:02",
+		LastSeen:   "2026-06-09T20:32:01",
+		LastChange: "2024-06-16T20:32:02",
+		Properties: TELProperties{
+			Program: []string{
+				"Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)",
+			},
+			Topics: []string{"sanction"},
+			Name: []string{
+				"Japanese Red Army (JRA)",
+				"JRA",
+			},
+		},
+		Target: true,
+	}
+
+	ent := r.ToEntity()
+
+	expName := "Japanese Red Army (JRA)"
+	if ent.Name != expName {
+		t.Errorf("expected Name %q, got %q", expName, ent.Name)
+	}
+
+	if ent.SourceID != r.ID {
+		t.Errorf("expected SourceID %q, got %q", r.ID, ent.SourceID)
+	}
+
+	if ent.Type != search.EntityBusiness {
+		t.Errorf("expected EntityBusiness, got %v", ent.Type)
+	}
+
+	if ent.Business == nil {
+		t.Fatal("Business pointer should not be nil")
+	}
+
+	if ent.Business.Name != expName {
+		t.Errorf("business name mismatch: expected %q got %q", expName, ent.Business.Name)
+	}
+
+	expAlts := []string{"JRA"}
+	if len(ent.Business.AltNames) != len(expAlts) {
+		t.Fatalf("expected %d alt names, got %d", len(expAlts), len(ent.Business.AltNames))
+	}
+
+	for i, v := range expAlts {
+		if ent.Business.AltNames[i] != v {
+			t.Errorf("alt name[%d] expected %q got %q", i, v, ent.Business.AltNames[i])
+		}
+	}
+}
+
+func TestTELRecord_ToEntity_UsesCaptionWhenNameMissing(t *testing.T) {
+	r := TELRecord{
+		ID:      "NK-46PWVzWZRu6PZ6YxW4emNg",
+		Caption: "Darkazanli Company",
+		Schema:  "LegalEntity",
+		Properties: TELProperties{
+			Program: []string{
+				"Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)",
+			},
+			Topics: []string{"sanction"},
+			Name:   []string{},
+		},
+		Target: true,
+	}
+
+	ent := r.ToEntity()
+
+	if ent.Name != r.Caption {
+		t.Errorf("expected Name from Caption %q, got %q", r.Caption, ent.Name)
+	}
+
+	if ent.Business == nil {
+		t.Fatal("Business pointer should not be nil")
+	}
+
+	if ent.Business.Name != r.Caption {
+		t.Errorf("expected Business.Name from Caption %q, got %q", r.Caption, ent.Business.Name)
+	}
+}
+
+func TestTELRecord_ToEntity_EmptyAliasesIgnored(t *testing.T) {
+	r := TELRecord{
+		ID:      "NK-AEU6mpsqUQKpqbR9nmQv23",
+		Caption: "Continuity Army Council",
+		Schema:  "LegalEntity",
+		Properties: TELProperties{
+			Name: []string{
+				"Continuity Army Council",
+				"",
+				"Continuity Irish Republican Army (CIRA)",
+			},
+			Topics: []string{"sanction"},
+		},
+		Target: true,
+	}
+
+	ent := r.ToEntity()
+
+	expAlts := []string{"Continuity Irish Republican Army (CIRA)"}
+
+	if ent.Business == nil {
+		t.Fatal("Business pointer should not be nil")
+	}
+
+	if len(ent.Business.AltNames) != len(expAlts) {
+		t.Fatalf("expected %d alt names, got %d", len(expAlts), len(ent.Business.AltNames))
+	}
+
+	for i, v := range expAlts {
+		if ent.Business.AltNames[i] != v {
+			t.Errorf("alt name[%d] expected %q got %q", i, v, ent.Business.AltNames[i])
+		}
+	}
+}

--- a/pkg/sources/us_tel/models.go
+++ b/pkg/sources/us_tel/models.go
@@ -1,0 +1,15 @@
+package us_tel
+
+type TELRecord struct {
+	ID         string        `json:"id"`
+	Caption    string        `json:"caption"`
+	Schema     string        `json:"schema"`
+	Referents  []string      `json:"referents"`
+	Datasets   []string      `json:"datasets"`
+	Origin     []string      `json:"origin"`
+	FirstSeen  string        `json:"first_seen"`
+	LastSeen   string        `json:"last_seen"`
+	LastChange string        `json:"last_change"`
+	Properties TELProperties `json:"properties"`
+	Target     bool          `json:"target"`
+}

--- a/pkg/sources/us_tel/reader.go
+++ b/pkg/sources/us_tel/reader.go
@@ -1,0 +1,89 @@
+package us_tel
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type TELProperties struct {
+	Program []string `json:"program"`
+	Topics  []string `json:"topics"`
+	Name    []string `json:"name"`
+}
+
+type Reader struct {
+	source io.Reader
+}
+
+func NewReader(r io.Reader) *Reader {
+	return &Reader{source: r}
+}
+
+func (r *Reader) Read(onRecord func(TELRecord)) error {
+	if r.source == nil {
+		return fmt.Errorf("source reader is nil")
+	}
+
+	br := bufio.NewReader(r.source)
+
+	// Peek at the first non-whitespace character to determine format
+	var firstByte byte
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if b == ' ' || b == '\t' || b == '\r' || b == '\n' {
+			continue
+		}
+		firstByte = b
+		err = br.UnreadByte()
+		if err != nil {
+			return err
+		}
+		break
+	}
+
+	decoder := json.NewDecoder(br)
+
+	if firstByte == '[' {
+		// Case 1: JSON Array
+		token, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("failed to read initial array token: %w", err)
+		}
+		if delim, ok := token.(json.Delim); !ok || delim != '[' {
+			return fmt.Errorf("expected JSON array starting with '['")
+		}
+
+		for decoder.More() {
+			var record TELRecord
+			if err := decoder.Decode(&record); err != nil {
+				return fmt.Errorf("failed to decode array record: %w", err)
+			}
+			onRecord(record)
+		}
+
+		_, err = decoder.Token()
+		return err
+	} else if firstByte == '{' {
+		// Case 2: JSON Lines (newline-delimited JSON objects)
+		for {
+			var record TELRecord
+			if err := decoder.Decode(&record); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return fmt.Errorf("failed to decode JSON lines record: %w", err)
+			}
+			onRecord(record)
+		}
+	}
+
+	return fmt.Errorf("expected JSON array starting with '[' or JSON Lines starting with '{', got %q", firstByte)
+}

--- a/test/testdata/us_tel.json
+++ b/test/testdata/us_tel.json
@@ -1,0 +1,237 @@
+[
+  {
+    "id": "NK-TST001aBcDeFgHiJkLmN",
+    "caption": "Crimson Dawn Network",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-terr-a1b2c3d4e5f6",
+      "ofac-10001"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-06-10T20:32:02",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-06-16T20:32:02",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Crimson Dawn Network"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST002qWeRtYuIoPaSd",
+    "caption": "Eastern Crescent Holdings",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-terr-b2c3d4e5f6g7",
+      "tw-shtc-20002",
+      "omnio-20002"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-07-01T10:15:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-07-10T11:20:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Eastern Crescent Holdings"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST003zXcVbNmAsDfGh",
+    "caption": "Al-Hikma Trading Center",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-terr-c3d4e5f6g7h8"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-08-05T08:00:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-08-20T08:00:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Al-Hikma Trading Center"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST004jKlMnOpQrStUv",
+    "caption": "Free Horizon Brigade",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-fto-d4e5f6g7h8i9",
+      "ofac-10004",
+      "au-dfat-40004"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-09-10T12:30:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-09-15T12:30:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Free Horizon Brigade"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST005wErTyUiOpAsDf",
+    "caption": "Northern Relief Foundation",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-terr-e5f6g7h8i9j0",
+      "omnio-50005"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-10-01T09:00:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-10-03T09:00:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Northern Relief Foundation"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST006yUiOpAsDfGhJk",
+    "caption": "Unity Resistance Front",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-fto-f6g7h8i9j0k1",
+      "gb-proscribed-60006",
+      "nz-terr-60006"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-11-11T11:11:11",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-11-20T11:11:11",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": [
+        "Unity Resistance Front",
+        "URF"
+      ]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST007rTyUiOpAsDfGhJ",
+    "caption": "Desert Star Logistics",
+    "schema": "LegalEntity",
+    "referents": [
+      "ofac-70007",
+      "usgsa-70007"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2024-12-01T06:45:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2024-12-08T06:45:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Desert Star Logistics"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST008uIoPaSdFgHjKl",
+    "caption": "People's Liberation Collective",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-terr-h8i9j0k1l2m3",
+      "permid-80008",
+      "ofac-80008"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2025-01-15T14:10:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2025-01-20T14:10:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": [
+        "People's Liberation Collective",
+        "PLC"
+      ]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST009pAsDfGhJkLmNo",
+    "caption": "Silver Coast Import Export",
+    "schema": "LegalEntity",
+    "referents": [
+      "tw-shtc-90009",
+      "omnio-90009",
+      "us-dos-terr-90009"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2025-02-01T13:00:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2025-02-10T13:00:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": ["Silver Coast Import Export"]
+    },
+    "target": true
+  },
+  {
+    "id": "NK-TST010lMnOpQrStUvWx",
+    "caption": "New Dawn Alliance",
+    "schema": "LegalEntity",
+    "referents": [
+      "us-dos-fto-01010",
+      "ofac-01010",
+      "au-dfat-01010",
+      "usgsa-01010"
+    ],
+    "datasets": ["us_state_terrorist_exclusion"],
+    "origin": ["inferred"],
+    "first_seen": "2025-03-15T07:30:00",
+    "last_seen": "2026-06-09T20:32:01",
+    "last_change": "2025-03-20T07:30:00",
+    "properties": {
+      "program": [
+        "Section 411 of the USA PATRIOT ACT of 2001 (8 U.S.C. § 1182) Terrorist Exclusion List (TEL)"
+      ],
+      "topics": ["sanction"],
+      "name": [
+        "New Dawn Alliance",
+        "NDA"
+      ]
+    },
+    "target": true
+  }
+]


### PR DESCRIPTION
## Overview
This PR integrates the US State Terrorist Exclusion List (US TEL) into Watchman. It  downloads, parses, indexes, displays, and provides default configs for US TEL data.

## 🤖 Agent Assistance
This PR was co-authored and implemented in collaboration with Claude Code (AI coding assistant), assisting with:

Bug Resolution: Identified and resolved the segmentation violation/panic in TestUSTelDownload_badURL by correcting the inverted check on the nil error returned by the download pipeline.

Pipeline Integration: Fully integrated the US TEL list loader into the coordinator's asynchronous refresh loop and mapped its display URLs.

Format Flexibility: Enhanced the US TEL file parser using bufio to dynamically parse both JSON Arrays (for cached files) and JSON Lines (for OpenSanctions web stream format).

Restoration: Cleaned up a package namespace collision where mapper files in the csl_un package had been accidentally overwritten with us_tel code.