### PR TITLE
perf: candidate index, admission control, and hot-path allocation cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Moov Watchman is a high-performance sanctions screening and compliance tool that
 - **Geocoding**: Using one of the supported providers.
 - **Senzing Support**: Import data files in [senzing format](https://www.senzing.com/docs/entity_specification/) and get search responses as senzing entities.
 - **Comprehensive Coverage**: Integrates multiple global watchlists in one unified system
-- **High-Performance Search**: Optimized for speed and accuracy using advanced matching algorithms
+- **High-Performance Search**: In-memory corpus with source/type partitions, name-token candidate indexes, and parallel Jaro-Winkler scoring (see [Performance](https://moov-io.github.io/watchman/performance/))
 - **Flexible Integration**: HTTP API and Go library for easy integration into your systems
 - **Automated Updates**: Regular refreshes of watchlist data to ensure compliance
 - **Model Context Protocol**: Integrate AI agents into screening workflows with MCP.
@@ -67,7 +67,7 @@ Moov Watchman is actively used in multiple production environments. Please star 
 
 The Watchman project implements an HTTP server, [Go library](https://pkg.go.dev/github.com/moov-io/watchman/pkg/search#Client), and experimental [Model Context Protocol (MCP)](https://moov-io.github.io/watchman/mcp/) server for searching against Watchman.
 
-Government lists are downloaded (and refreshed), parsed, prepared, normalized, and indexed in-memory. Searches operate concurrently and do not require an external database or connection.
+Government lists are downloaded (and refreshed), parsed, prepared, normalized, and indexed in-memory. On each refresh Watchman builds source/type partitions and inverted name-token indexes so searches score a candidate set (with safe fallback to a full partition) rather than always scanning every entity. Scoring runs concurrently with admission control and does not require an external database. Prefer `type` and `source` on `/v2/search` for best latency—see [Performance](https://moov-io.github.io/watchman/performance/) and [Indexing](https://moov-io.github.io/watchman/indexing/).
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Moov Watchman is a high-performance sanctions screening and compliance tool that
 - **Geocoding**: Using one of the supported providers.
 - **Senzing Support**: Import data files in [senzing format](https://www.senzing.com/docs/entity_specification/) and get search responses as senzing entities.
 - **Comprehensive Coverage**: Integrates multiple global watchlists in one unified system
-- **High-Performance Search**: In-memory corpus with source/type partitions, name-token candidate indexes, and parallel Jaro-Winkler scoring (see [Performance](https://moov-io.github.io/watchman/performance/))
+- **High-Performance Search**: In-memory corpus with source/type partitions, name-token and crypto candidate indexes, admission control, and parallel Jaro-Winkler scoring (see [Performance](https://moov-io.github.io/watchman/performance/) and [Indexing](https://moov-io.github.io/watchman/indexing/))
 - **Flexible Integration**: HTTP API and Go library for easy integration into your systems
 - **Automated Updates**: Regular refreshes of watchlist data to ensure compliance
 - **Model Context Protocol**: Integrate AI agents into screening workflows with MCP.
@@ -67,7 +67,7 @@ Moov Watchman is actively used in multiple production environments. Please star 
 
 The Watchman project implements an HTTP server, [Go library](https://pkg.go.dev/github.com/moov-io/watchman/pkg/search#Client), and experimental [Model Context Protocol (MCP)](https://moov-io.github.io/watchman/mcp/) server for searching against Watchman.
 
-Government lists are downloaded (and refreshed), parsed, prepared, normalized, and indexed in-memory. On each refresh Watchman builds source/type partitions and inverted name-token indexes so searches score a candidate set (with safe fallback to a full partition) rather than always scanning every entity. Scoring runs concurrently with admission control and does not require an external database. Prefer `type` and `source` on `/v2/search` for best latency—see [Performance](https://moov-io.github.io/watchman/performance/) and [Indexing](https://moov-io.github.io/watchman/indexing/).
+Government lists are downloaded (and refreshed), parsed, prepared, normalized, and indexed in-memory. On each refresh Watchman builds source/type partitions, inverted name-token indexes, exact-name maps, and crypto address lookups so searches score a **candidate set** (with safe fallback to a full *source/type partition* on name typos) rather than always scanning every entity. Candidate selection runs before admission control; tightly pruned queries (≤100 candidates) skip the queue. Prefer `type` and `source` on `/v2/search` for best latency—see [Performance](https://moov-io.github.io/watchman/performance/), [Indexing](https://moov-io.github.io/watchman/indexing/), and [Configuration](https://moov-io.github.io/watchman/config/#similarity-configuration) (`SEARCH_MAX_IN_FLIGHT`, `SEARCH_GOROUTINE_COUNT`).
 
 ### Docker
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ menubar: docs-menu
 
 1. [TF-IDF Configuration](#tf-idf-configuration)
 1. [Cross Script Embeddings Configuration](#cross-script-embeddings-configuration)
-1. [Similarity Configuration](#similarity-configuration)
+1. [Similarity Configuration](#similarity-configuration) (`SEARCH_MAX_IN_FLIGHT`, Jaro-Winkler flags, etc.)
 
 #### Source List Configuration
 
@@ -114,9 +114,15 @@ Watchman:
       Min: 1
       Max: 25
 
+    # Max concurrent full searches admitted at once (admission control).
+    # 0 or omit = GOMAXPROCS. Override with SEARCH_MAX_IN_FLIGHT.
+    # MaxInFlight: 8
+
     Embeddings:
       Enabled: false # See below for Cross-Script Embeddings
 ```
+
+See [Performance](/watchman/performance/) for how admission control, per-search workers, and candidate indexes interact under load.
 
 ### Geocoding
 
@@ -213,6 +219,7 @@ Watchman integrates the following lists to help you maintain global compliance.
 [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) (Term Frequency–Inverse Document Frequency) is a technique used to measure the importance of a word in a corpus. Less frequent words are more important.
 
 By default Watchman does not employ TF-IDF, but it can be enabled and configured with the following environmental variables.
+When enabled, term weights for indexed entities are computed once at list refresh and attached to each entity; query weights are computed once per search.
 
 | Environmental Variable | Description                                                                                                    | Default |
 |------------------------|----------------------------------------------------------------------------------------------------------------|---------|
@@ -275,6 +282,7 @@ YAML configuration (example with OpenAI):
 
 | Environmental Variable             | Description                                                                                                   | Default |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------|---------|
+| `SEARCH_MAX_IN_FLIGHT`             | Maximum number of concurrent full searches admitted at once. Extra requests wait. `0` / empty uses `GOMAXPROCS`. | `GOMAXPROCS` |
 | `SEARCH_GOROUTINE_COUNT`           | Set a fixed number of goroutines used for each search. Default is to dynamically optimize for faster results. | Empty   |
 | `KEEP_STOPWORDS`                   | Boolean to keep stopwords in names.                                                                           | `false` |
 | `JARO_WINKLER_BOOST_THRESHOLD`     | Jaro-Winkler boost threshold.                                                                                 | 0.7     |
@@ -288,9 +296,11 @@ YAML configuration (example with OpenAI):
 | `FINAL_SCORE_LOW_COVERAGE_MULTIPLIER`        | Multiplier applied when a query compares against too little of the indexed entity's available data.              | 0.95    |
 | `FINAL_SCORE_MIN_REQUIRED_FIELDS_MULTIPLIER` | Multiplier applied when a search compares fewer than two required fields, such as a name-only query.              | 0.90    |
 | `FINAL_SCORE_NAME_ONLY_MULTIPLIER`           | Multiplier applied to name-only matches when no IDs or addresses are present in the query.                    | 0.95    |
-| `DISABLE_PHONETIC_FILTERING`       | Force scoring search terms against every indexed record.                                                      | `false` |
-| `USE_SOUNDEX_MATCHING`             | Enable full Soundex phonetic code matching to optionally boost Jaro-Winkler scores for phonetically similar names (e.g. "Smith" vs "Smythe"). | `false` |
-| `SOUNDEX_BOOST_WEIGHT`             | When `USE_SOUNDEX_MATCHING=yes`, the boost factor applied to pairs whose Soundex codes match (score *= 1+weight, capped at 1.0). Example: `0.12` for a 12% boost. | `0.0`   |
+| `DISABLE_PHONETIC_FILTERING`       | Force comparing search tokens against every index token (skip first-letter phonetic filter inside Jaro-Winkler). Loaded at process start. | `false` |
+| `USE_SOUNDEX_MATCHING`             | Enable full Soundex phonetic code matching to optionally boost Jaro-Winkler scores for phonetically similar names (e.g. "Smith" vs "Smythe"). Loaded at process start. | `false` |
+| `SOUNDEX_BOOST_WEIGHT`             | When `USE_SOUNDEX_MATCHING=yes`, the boost factor applied to pairs whose Soundex codes match (score *= 1+weight, capped at 1.0). Example: `0.12` for a 12% boost. Loaded at process start. | `0.0`   |
+
+> **Note:** `DISABLE_PHONETIC_FILTERING`, `USE_SOUNDEX_MATCHING`, and `SOUNDEX_BOOST_WEIGHT` are read once at process startup for hot-path performance. Restart Watchman after changing them.
 
 #### Source List Configuration
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -114,7 +114,9 @@ Watchman:
       Min: 1
       Max: 25
 
-    # Max concurrent full searches admitted at once (admission control).
+    # Max concurrent *large* searches admitted at once (admission control).
+    # Candidate selection runs first; sets with <= 100 entities bypass the queue
+    # so exact/crypto hits are not blocked behind full-partition scans.
     # 0 or omit = GOMAXPROCS. Override with SEARCH_MAX_IN_FLIGHT.
     # MaxInFlight: 8
 
@@ -282,7 +284,7 @@ YAML configuration (example with OpenAI):
 
 | Environmental Variable             | Description                                                                                                   | Default |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------|---------|
-| `SEARCH_MAX_IN_FLIGHT`             | Maximum number of concurrent full searches admitted at once. Extra requests wait. `0` / empty uses `GOMAXPROCS`. | `GOMAXPROCS` |
+| `SEARCH_MAX_IN_FLIGHT`             | Maximum number of concurrent *large* searches admitted at once (candidate set &gt; 100). Smaller sets bypass the queue. Extra large searches wait. `0` / empty uses `GOMAXPROCS`. | `GOMAXPROCS` |
 | `SEARCH_GOROUTINE_COUNT`           | Set a fixed number of goroutines used for each search. Default is to dynamically optimize for faster results. | Empty   |
 | `KEEP_STOPWORDS`                   | Boolean to keep stopwords in names.                                                                           | `false` |
 | `JARO_WINKLER_BOOST_THRESHOLD`     | Jaro-Winkler boost threshold.                                                                                 | 0.7     |

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,8 @@ Watchman empowers your compliance team with powerful tools designed for accuracy
 
 - **Comprehensive Global Coverage**: Seamlessly integrates multiple international sanctions lists, ensuring thorough compliance screening across jurisdictions.
 - **Advanced Fuzzy Matching**: Leverages sophisticated algorithms to detect name variations and reduce false negatives, saving time on manual reviews.
-- **High-Performance Search**: Delivers lightning-fast queries with optimized in-memory processing for real-time compliance checks.
+- **High-Performance Search**: In-memory corpus with source/type partitions, name-token and crypto candidate indexes, and parallel scoring for real-time compliance checks. See [Performance](/watchman/performance/) and [Indexing](/watchman/indexing/).
+
 - **Flexible Integration Options**: Provides an intuitive HTTP API and native Go library for seamless incorporation into your existing systems.
 - **Automated Data Management**: Handles automatic downloads and refreshes of watchlists, keeping your data current without manual intervention.
 - **Customizable Configuration**: Fine-tune search parameters, thresholds, and behaviors to align with your organization's specific risk profile. See [Configuration Guide](/watchman/config/) for details.

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -11,6 +11,34 @@ menubar: docs-menu
 Watchman maintains searchable entities in memory (with database options for ingested files) to deliver ultra-fast search responses.
 The index automatically rebuilds with each data refresh, ensuring your compliance checks are always based on the latest information.
 
+## What is built on refresh
+
+When lists finish downloading and preparing, Watchman constructs an in-memory **search corpus** from every entity:
+
+1. **Prepared fields** — normalized names, tokenized name fields (stopwords removed), alt names, former names, addresses, and contact data (see [pipeline](/watchman/pipeline/) and entity `Normalize()`).
+2. **Source × type partitions** — index slices keyed by list source and entity type so queries with `source` / `type` only score the relevant subset.
+3. **Name-token inverted index** — maps each significant prepared name token to entity positions (primary name, alternate names, and historical “Former Name” values).
+4. **Crypto address index** — exact lookup by `CURRENCY:address` for fast crypto screening.
+5. **Optional TF-IDF weights** — when enabled, term weights for each entity’s name fields are stored on the entity so search does not recompute them per comparison.
+
+These structures are immutable for readers until the next successful refresh replaces the corpus atomically.
+
+## Candidate selection at search time
+
+Before Jaro-Winkler scoring, Watchman selects a **candidate set**:
+
+| Query shape | Candidate strategy |
+|-------------|-------------------|
+| `type` and/or `source` set | Start from that partition only |
+| Name tokens present | Union of inverted-index hits for those tokens, restricted to the partition |
+| No token hits (e.g. heavy typos) | **Fall back to the full partition** (preserves recall) |
+| Crypto address on query | Exact crypto hits (merged with name candidates when both are present) |
+| Name-less / identifier-oriented | Full partition for the filtered source/type |
+
+If candidates would cover most of the partition (default threshold: half the partition size), Watchman scores the full partition instead—token pruning would not save work.
+
+Always pass **`type`** (and **`source`** when appropriate) on `/v2/search` for the best latency. See [Performance](/watchman/performance/) for concurrency and tuning.
+
 ## TF-IDF
 
 Starting with `v0.57.0` Watchman builds an in-memory [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf)
@@ -23,6 +51,9 @@ ones (e.g., "bank" or frequent first names) are downweighted.
 During name searches, TF-IDF weighting is optionally applied to boost the contribution of discriminative rare terms
 in similarity scoring, improving match precision for fuzzy name matching against global sanctions and watchlists
 without overemphasizing ubiquitous words.
+
+When TF-IDF is enabled, weights for indexed entities are **materialized at corpus build time** and attached to each
+entity’s prepared fields. Query-side weights are computed once per search request.
 
 The feature is opt-in via [configuration, with tunable parameters](/watchman/config/#tf-idf-configuration) like
 smoothing and IDF bounds to adapt to corpus size and growth.

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -16,10 +16,11 @@ The index automatically rebuilds with each data refresh, ensuring your complianc
 When lists finish downloading and preparing, Watchman constructs an in-memory **search corpus** from every entity:
 
 1. **Prepared fields** — normalized names, tokenized name fields (stopwords removed), alt names, former names, addresses, and contact data (see [pipeline](/watchman/pipeline/) and entity `Normalize()`).
-2. **Source × type partitions** — index slices keyed by list source and entity type so queries with `source` / `type` only score the relevant subset.
-3. **Name-token inverted index** — maps each significant prepared name token to entity positions (primary name, alternate names, and historical “Former Name” values).
-4. **Crypto address index** — exact lookup by `CURRENCY:address` for fast crypto screening.
-5. **Optional TF-IDF weights** — when enabled, term weights for each entity’s name fields are stored on the entity so search does not recompute them per comparison.
+2. **Source × type partitions** — index slices keyed by list source and entity type so queries with `source` / `type` only score the relevant subset. Empty source or type values are not double-counted into the “all” partition.
+3. **Name-token inverted index** — maps each significant prepared name token to entity positions (primary name, alternate names, and historical “Former Name” values). Each entity is posted **once per distinct token** even if the token repeats across name fields.
+4. **Exact prepared-name map** — maps the full prepared name string to entity positions for exact-name shortcuts.
+5. **Crypto address index** — exact lookup by `CURRENCY:address` for fast crypto screening.
+6. **Optional TF-IDF weights** — when enabled, term weights for each entity’s name fields are stored on the entity so search does not recompute them per comparison.
 
 These structures are immutable for readers until the next successful refresh replaces the corpus atomically.
 
@@ -30,14 +31,20 @@ Before Jaro-Winkler scoring, Watchman selects a **candidate set**:
 | Query shape | Candidate strategy |
 |-------------|-------------------|
 | `type` and/or `source` set | Start from that partition only |
+| Known source, empty type (no entities of that type) | **Empty result** — does not scan other types or sources |
+| Unknown / unregistered source | **Empty result** — does not fall back to the full corpus |
 | Name tokens present | Union of inverted-index hits for those tokens, restricted to the partition |
-| No token hits (e.g. heavy typos) | **Fall back to the full partition** (preserves recall) |
-| Crypto address on query | Exact crypto hits (merged with name candidates when both are present) |
-| Name-less / identifier-oriented | Full partition for the filtered source/type |
+| No token hits (e.g. heavy typos) | **Fall back to the full partition** (preserves recall within that source/type) |
+| Crypto address only | Exact crypto hits only (does not expand to the full partition) |
+| Crypto + name tokens | Union of crypto hits and name-token candidates |
+| Exact prepared name (no tokens after stopwords) | Binary-search exact-name postings against the partition |
+| Name-less / identifier-oriented (no crypto) | Full partition for the filtered source/type |
 
-If candidates would cover most of the partition (default threshold: half the partition size), Watchman scores the full partition instead—token pruning would not save work.
+If name-token candidates would cover most of the partition (default threshold: half the partition size), Watchman scores the full partition instead—token pruning would not save work.
 
-Always pass **`type`** (and **`source`** when appropriate) on `/v2/search` for the best latency. See [Performance](/watchman/performance/) for concurrency and tuning.
+Candidate index membership checks use binary search over sorted partition slices (no per-query partition maps). Duplicate postings are removed with sort + compact.
+
+Always pass **`type`** (and **`source`** when appropriate) on `/v2/search` for the best latency. See [Performance](/watchman/performance/) for concurrency, admission control, and tuning.
 
 ## TF-IDF
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,9 +20,9 @@ Watchman delivers enterprise-grade compliance screening with:
    - Custom data file support for specialized screening needs
 
 2. **Search Capabilities**:
-   - High-performance in-memory indexing (source/type partitions, name-token candidates, optional TF-IDF)
-   - Advanced fuzzy matching using Jaro-Winkler algorithms
-   - Multi-field search with entity type filtering and concurrent scoring
+   - High-performance in-memory indexing (source/type partitions, name-token and crypto candidates, optional TF-IDF)
+   - Advanced fuzzy matching using Jaro-Winkler algorithms with exact-ID short-circuit
+   - Multi-field search with entity type filtering, admission control, and concurrent scoring
 
  3. **Integration Options**:
     - HTTP API for web and service integration

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,9 +20,9 @@ Watchman delivers enterprise-grade compliance screening with:
    - Custom data file support for specialized screening needs
 
 2. **Search Capabilities**:
-   - High-performance indexing and search functionality
+   - High-performance in-memory indexing (source/type partitions, name-token candidates, optional TF-IDF)
    - Advanced fuzzy matching using Jaro-Winkler algorithms
-   - Multi-field search with entity type filtering
+   - Multi-field search with entity type filtering and concurrent scoring
 
  3. **Integration Options**:
     - HTTP API for web and service integration

--- a/docs/methodology/index.md
+++ b/docs/methodology/index.md
@@ -134,23 +134,27 @@ Watchman allows customizing match thresholds for different risk tolerances:
 
 ## Performance Optimizations
 
-Watchman includes several performance enhancements:
+Watchman includes several performance enhancements. See [Performance](/watchman/performance/) and [Indexing](/watchman/indexing/) for operational detail.
 
-1. **Early Termination**
-   - Once a high-confidence match is found, detailed scoring may be skipped
-   - Reduces processing time for obvious matches
+1. **Corpus partitions and candidate indexes**
+   - Entities are partitioned by source and type at index time
+   - Name-token inverted indexes and exact crypto lookups select candidates before full similarity scoring
+   - Empty token hits fall back to a full partition scan so recall is preserved
 
-2. **Phonetic Pre-filtering**
-   - Initial filtering based on phonetic codes
-   - Narrows candidate pool before expensive comparison
+2. **Phonetic filtering inside Jaro-Winkler**
+   - First-character phonetic classes skip unlikely token pairs before running full Jaro-Winkler
+   - Optional full Soundex boost when `USE_SOUNDEX_MATCHING` is enabled
 
-3. **Caching**
-   - Frequently searched entities are cached
-   - Improves performance for common searches
+3. **Precomputed prepared fields**
+   - Names, alt names, former names, addresses, and optional TF-IDF weights are prepared at index/query normalize time
+   - Bulk scoring avoids re-normalizing index entities on every comparison
 
-4. **Parallel Processing**
-   - Multi-threaded search for large entity sets
-   - Scales with available CPU cores
+4. **Parallel scoring with admission control**
+   - Each search fans out across a dynamic worker pool; workers keep local top-K heaps and merge at the end
+   - `SEARCH_MAX_IN_FLIGHT` bounds concurrent searches so stacked worker pools do not oversubscribe CPUs
+
+5. **Address high-confidence short-circuit**
+   - Within a single address pair comparison, scoring can stop early once a high-confidence field match is found
 
 ## Benefits for Compliance Teams
 

--- a/docs/methodology/index.md
+++ b/docs/methodology/index.md
@@ -138,8 +138,9 @@ Watchman includes several performance enhancements. See [Performance](/watchman/
 
 1. **Corpus partitions and candidate indexes**
    - Entities are partitioned by source and type at index time
-   - Name-token inverted indexes and exact crypto lookups select candidates before full similarity scoring
-   - Empty token hits fall back to a full partition scan so recall is preserved
+   - Name-token inverted indexes, exact-name maps, and crypto lookups select candidates before full similarity scoring
+   - Empty type/source partitions return no candidates (no cross-list leak)
+   - Empty name-token hits fall back to a full *partition* scan so recall is preserved within that filter
 
 2. **Phonetic filtering inside Jaro-Winkler**
    - First-character phonetic classes skip unlikely token pairs before running full Jaro-Winkler
@@ -148,10 +149,12 @@ Watchman includes several performance enhancements. See [Performance](/watchman/
 3. **Precomputed prepared fields**
    - Names, alt names, former names, addresses, and optional TF-IDF weights are prepared at index/query normalize time
    - Bulk scoring avoids re-normalizing index entities on every comparison
+   - Critical exact ID/crypto/contact matches short-circuit to a perfect score without full fuzzy work
 
 4. **Parallel scoring with admission control**
-   - Each search fans out across a dynamic worker pool; workers keep local top-K heaps and merge at the end
-   - `SEARCH_MAX_IN_FLIGHT` bounds concurrent searches so stacked worker pools do not oversubscribe CPUs
+   - Candidate selection runs first; searches with ≤100 candidates skip the admission queue
+   - Larger searches acquire `SEARCH_MAX_IN_FLIGHT` so stacked worker pools do not oversubscribe CPUs
+   - Multi-worker searches use local top-K heaps and merge; single-worker paths score directly into the final heap
 
 5. **Address high-confidence short-circuit**
    - Within a single address pair comparison, scoring can stop early once a high-confidence field match is found

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,10 +33,13 @@ Each `/v2/search` request roughly follows this path:
 
 1. **Parse and normalize** the query (names, addresses, IDs).
 2. **Select candidates** from the in-memory corpus using prebuilt indexes (see [Indexing](/watchman/indexing/)).
-3. **Score candidates in parallel** with Jaro-Winkler similarity (and optional TF-IDF weighting).
-4. **Keep a top-N heap** of the best matches above `minMatch`, then return JSON.
+3. **Admission control** (only when the candidate set is large — see below).
+4. **Score candidates** with Jaro-Winkler similarity (and optional TF-IDF weighting), in parallel when needed.
+5. **Keep a top-N heap** of the best matches above `minMatch`, then return JSON.
 
 Candidate selection is **recall-safe relative to a full source/type partition scan**: if name tokens do not hit the inverted index (for example a pure typo with no shared tokens), Watchman falls back to scoring the entire matching partition rather than returning empty results.
+
+Empty partitions (for example `type=aircraft` when that source has no aircraft) return **no candidates** — Watchman does not fall back to scanning unrelated sources or types.
 
 ### Candidate selection
 
@@ -45,7 +48,8 @@ On every list refresh Watchman builds:
 | Structure | Purpose |
 |-----------|---------|
 | **Source × type partitions** | Restrict scoring to the requested `source` and/or `type` when provided |
-| **Name-token inverted index** | Union of entities whose prepared primary, alt, or former names contain a query token |
+| **Name-token inverted index** | Union of entities whose prepared primary, alt, or former names contain a query token (one posting per token per entity) |
+| **Exact prepared-name map** | Fast path when the full prepared name matches exactly |
 | **Crypto address map** | Exact `CURRENCY:address` lookup for crypto-only (or crypto+name) queries |
 | **TF-IDF term weights** (optional) | Precomputed per-entity weights so search does not recompute IDF on every comparison |
 
@@ -53,17 +57,21 @@ On every list refresh Watchman builds:
 
 - Always send `type=` (and `source=` when you only need one list). This shrinks the partition before token lookup.
 - Prefer multi-token names when possible; shared tokens prune the candidate set aggressively.
-- Identifier-heavy queries (crypto addresses, government IDs) use exact paths where available; name-less ID scans still use the type/source partition.
+- Crypto-only queries use the exact address index and do **not** expand to a full partition scan.
+- Identifier-heavy queries (government IDs, contact info) still score within the type/source partition; critical exact ID matches short-circuit similarity to a perfect score without running full name/address comparison.
 
 ### Concurrency model
 
 Watchman uses two layers of concurrency control:
 
-1. **Admission control (`SEARCH_MAX_IN_FLIGHT`)** — limits how many full searches run at once (default: `GOMAXPROCS`). Extra requests wait rather than oversubscribing every CPU with stacked worker pools. Tune this when you run many concurrent clients against one instance.
+1. **Admission control (`SEARCH_MAX_IN_FLIGHT`)** — limits how many *large* searches run at once (default: `GOMAXPROCS`). Candidate selection runs **before** the semaphore. When the candidate set has **100 or fewer** entities (exact crypto hits, tightly pruned name queries, empty partitions), the search **bypasses** the queue so fast lookups are not blocked behind full-partition scans. Larger candidate sets acquire a slot; extra requests wait rather than oversubscribing every CPU with stacked worker pools.
 
-2. **Per-search worker pool** — each admitted search fans out scoring across a dynamic number of goroutines (`Search.Goroutines` in config, or a fixed `SEARCH_GOROUTINE_COUNT`). A feedback loop (concurrency champion) adjusts the worker count based on recent search durations for stable latency on shared hardware.
+2. **Per-search worker pool** — each search fans out scoring across a dynamic number of goroutines (`Search.Goroutines` in config, or a fixed `SEARCH_GOROUTINE_COUNT`). A feedback loop (concurrency champion) adjusts the worker count based on recent search durations for stable latency on shared hardware.
 
-Each worker maintains a **local top-K** of best matches and merges into the final result set after scoring, avoiding a shared mutex on every entity comparison.
+**Worker sizing**
+
+- If there is only one worker (common after heavy pruning), scoring writes directly into the final top-K heap — no per-worker buffers or merge step.
+- With multiple workers, each maintains a **local top-K** and merges into the final result set after scoring, avoiding a shared mutex on every entity comparison.
 
 As shown in the first graph below, which tracks search requests per second (req/s) over time, Watchman maintains consistent query performance despite fluctuating load.
 
@@ -80,6 +88,7 @@ encouraging richer query data for better performance.
 Similarity scoring is allocation-conscious for bulk search:
 
 - Score pieces are computed on the stack for the non-debug path.
+- Critical exact matches (government IDs, crypto addresses, contact identifiers) **return 1.0 immediately** and skip expensive name/title/address comparison.
 - Former names and related prepared fields are normalized at index time (and query normalize), not on every comparison.
 - Optional TF-IDF weights are attached to index entities when lists load; query weights are computed once per search.
 - Jaro-Winkler feature flags (`DISABLE_PHONETIC_FILTERING`, `USE_SOUNDEX_MATCHING`, `SOUNDEX_BOOST_WEIGHT`) are read at process start (see [Similarity Configuration](/watchman/config/#similarity-configuration)). Changing them requires a restart.
@@ -90,7 +99,7 @@ Debug mode (`debug=true`) is substantially more expensive (extra buffers and det
 
 | Variable / setting | Role |
 |--------------------|------|
-| `SEARCH_MAX_IN_FLIGHT` | Max concurrent searches (admission control); default `GOMAXPROCS` |
+| `SEARCH_MAX_IN_FLIGHT` | Max concurrent *large* searches (admission control); default `GOMAXPROCS`. Candidate sets ≤ 100 skip the queue. |
 | `SEARCH_GOROUTINE_COUNT` | Fixed workers per search; empty = dynamic champion |
 | `Search.Goroutines` | Default / min / max for dynamic workers |
 | `TFIDF_ENABLED` | Optional name-term weighting (index-time weights) |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,13 +27,72 @@ The trade-off is that data is reloaded on restart, but this ensures freshness an
 Jaro-Winkler algorithm, Watchman delivers quick and accurate fuzzy matching for names and addresses, with scoring from 0.0 (no match) to 1.0 (exact match).
 The in-memory approach, paired with precomputed indexes, allows Watchman to handle large query volumes without relying on an external database.
 
-To manage high throughput, Watchman employs **dynamic concurrency with goroutines**. It uses a feedback loop to adjust the number of goroutines based on load, ensuring stable response
-times even on shared hardware. As shown in the first graph below, which tracks search requests per second (req/s) over time, Watchman maintains consistent query performance despite fluctuating load.
+## How a search is executed
+
+Each `/v2/search` request roughly follows this path:
+
+1. **Parse and normalize** the query (names, addresses, IDs).
+2. **Select candidates** from the in-memory corpus using prebuilt indexes (see [Indexing](/watchman/indexing/)).
+3. **Score candidates in parallel** with Jaro-Winkler similarity (and optional TF-IDF weighting).
+4. **Keep a top-N heap** of the best matches above `minMatch`, then return JSON.
+
+Candidate selection is **recall-safe relative to a full source/type partition scan**: if name tokens do not hit the inverted index (for example a pure typo with no shared tokens), Watchman falls back to scoring the entire matching partition rather than returning empty results.
+
+### Candidate selection
+
+On every list refresh Watchman builds:
+
+| Structure | Purpose |
+|-----------|---------|
+| **Source × type partitions** | Restrict scoring to the requested `source` and/or `type` when provided |
+| **Name-token inverted index** | Union of entities whose prepared primary, alt, or former names contain a query token |
+| **Crypto address map** | Exact `CURRENCY:address` lookup for crypto-only (or crypto+name) queries |
+| **TF-IDF term weights** (optional) | Precomputed per-entity weights so search does not recompute IDF on every comparison |
+
+**Tips for faster queries**
+
+- Always send `type=` (and `source=` when you only need one list). This shrinks the partition before token lookup.
+- Prefer multi-token names when possible; shared tokens prune the candidate set aggressively.
+- Identifier-heavy queries (crypto addresses, government IDs) use exact paths where available; name-less ID scans still use the type/source partition.
+
+### Concurrency model
+
+Watchman uses two layers of concurrency control:
+
+1. **Admission control (`SEARCH_MAX_IN_FLIGHT`)** — limits how many full searches run at once (default: `GOMAXPROCS`). Extra requests wait rather than oversubscribing every CPU with stacked worker pools. Tune this when you run many concurrent clients against one instance.
+
+2. **Per-search worker pool** — each admitted search fans out scoring across a dynamic number of goroutines (`Search.Goroutines` in config, or a fixed `SEARCH_GOROUTINE_COUNT`). A feedback loop (concurrency champion) adjusts the worker count based on recent search durations for stable latency on shared hardware.
+
+Each worker maintains a **local top-K** of best matches and merges into the final result set after scoring, avoiding a shared mutex on every entity comparison.
+
+As shown in the first graph below, which tracks search requests per second (req/s) over time, Watchman maintains consistent query performance despite fluctuating load.
 
 ![Graph 1: Stable query times with search req/s over time](../images/stable-response-times.png)
 
-The second graph illustrates how Watchman dynamically adjusts goroutine group sizes, optimizing for overall time to score and keeping response timings steady (typically between 250-1000 ms).
+The second graph illustrates how Watchman dynamically adjusts goroutine group sizes, optimizing for overall time to score and keeping response timings steady.
 This concurrency model was a significant improvement over earlier versions, where consistent load could cause slowdowns or crashes. The v0.5x series further refined this by consolidating to a single search model,
 encouraging richer query data for better performance.
 
 ![Graph 2: Dynamic adjustment of goroutine group sizes for optimal scoring time](../images/dynamic-goroutines.png)
+
+## Scoring hot path
+
+Similarity scoring is allocation-conscious for bulk search:
+
+- Score pieces are computed on the stack for the non-debug path.
+- Former names and related prepared fields are normalized at index time (and query normalize), not on every comparison.
+- Optional TF-IDF weights are attached to index entities when lists load; query weights are computed once per search.
+- Jaro-Winkler feature flags (`DISABLE_PHONETIC_FILTERING`, `USE_SOUNDEX_MATCHING`, `SOUNDEX_BOOST_WEIGHT`) are read at process start (see [Similarity Configuration](/watchman/config/#similarity-configuration)). Changing them requires a restart.
+
+Debug mode (`debug=true`) is substantially more expensive (extra buffers and detailed score pieces) and should stay off in production traffic.
+
+## Related configuration
+
+| Variable / setting | Role |
+|--------------------|------|
+| `SEARCH_MAX_IN_FLIGHT` | Max concurrent searches (admission control); default `GOMAXPROCS` |
+| `SEARCH_GOROUTINE_COUNT` | Fixed workers per search; empty = dynamic champion |
+| `Search.Goroutines` | Default / min / max for dynamic workers |
+| `TFIDF_ENABLED` | Optional name-term weighting (index-time weights) |
+
+See the full [Configuration Guide](/watchman/config/) and [Indexing](/watchman/indexing/) pages for details.

--- a/docs/search.md
+++ b/docs/search.md
@@ -46,7 +46,7 @@ The API requires specifying an entity type:
 | `aircraft` | Aircraft registrations | `?type=aircraft&callSign=EP-GOM` |
 | `vessel` | Maritime vessels | `?type=vessel&imoNumber=9401598` |
 
-> **Performance:** Always include `type` (and `source` when you only need one list). Watchman partitions the in-memory corpus by source and type and uses name-token indexes to select candidates before fuzzy scoring. See [Performance](/watchman/performance/) and [Indexing](/watchman/indexing/).
+> **Performance:** Always include `type` (and `source` when you only need one list). Watchman partitions the in-memory corpus by source and type and uses name-token / crypto indexes to select candidates before fuzzy scoring. Empty type partitions return no matches (they do not scan other lists). Crypto-only queries use an exact address index. See [Performance](/watchman/performance/) and [Indexing](/watchman/indexing/).
 
 ### Advanced Entity Search Parameters
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -46,6 +46,8 @@ The API requires specifying an entity type:
 | `aircraft` | Aircraft registrations | `?type=aircraft&callSign=EP-GOM` |
 | `vessel` | Maritime vessels | `?type=vessel&imoNumber=9401598` |
 
+> **Performance:** Always include `type` (and `source` when you only need one list). Watchman partitions the in-memory corpus by source and type and uses name-token indexes to select candidates before fuzzy scoring. See [Performance](/watchman/performance/) and [Indexing](/watchman/indexing/).
+
 ### Advanced Entity Search Parameters
 
 Each entity type supports specific search parameters:

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -234,7 +234,13 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 	// Exact prepared name shortcut (name set but fields empty after stopwords)
 	if name := query.PreparedFields.Name; name != "" {
 		if exact := c.exactNames[name]; len(exact) > 0 {
-			filtered := intersectSorted(exact, partition)
+			// exact is tiny; binary-search each index in the (large) sorted partition
+			var filtered []int
+			for _, idx := range exact {
+				if _, found := slices.BinarySearch(partition, idx); found {
+					filtered = append(filtered, idx)
+				}
+			}
 			if len(filtered) > 0 {
 				return c.materialize(filtered)
 			}
@@ -286,27 +292,6 @@ func (c *corpus) materialize(idxs []int) []search.Entity[search.Value] {
 	out := make([]search.Entity[search.Value], len(idxs))
 	for i, idx := range idxs {
 		out[i] = c.entities[idx]
-	}
-	return out
-}
-
-// intersectSorted returns intersection of two ascending slices.
-func intersectSorted(a, b []int) []int {
-	if len(a) == 0 || len(b) == 0 {
-		return nil
-	}
-	var out []int
-	i, j := 0, 0
-	for i < len(a) && j < len(b) {
-		if a[i] == b[j] {
-			out = append(out, a[i])
-			i++
-			j++
-		} else if a[i] < b[j] {
-			i++
-		} else {
-			j++
-		}
 	}
 	return out
 }

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -1,0 +1,308 @@
+package index
+
+import (
+	"strings"
+
+	"github.com/moov-io/watchman/internal/tfidf"
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// corpus holds precomputed search structures built when lists are updated.
+// All fields are immutable after Build and safe for concurrent readers.
+type corpus struct {
+	entities []search.Entity[search.Value]
+	tfidf    *tfidf.Index
+
+	// bySourceType maps source -> entityType -> indices into entities.
+	// Empty string keys mean "all sources" / "all types".
+	bySourceType map[string]map[string][]int
+
+	// nameTokens maps a prepared name token to entity indices that contain it
+	// in primary, alt, or historical names.
+	nameTokens map[string][]int
+
+	// exactNames maps prepared full name -> entity indices.
+	exactNames map[string][]int
+
+	// cryptoKeys maps "CURRENCY:address" (upper currency) -> entity indices.
+	cryptoKeys map[string][]int
+}
+
+// buildCorpus constructs partitions and inverted indexes from the entity list.
+// It also attaches precomputed TF-IDF term weights onto each entity's PreparedFields.
+func buildCorpus(entities []search.Entity[search.Value], tfidfIndex *tfidf.Index) *corpus {
+	c := &corpus{
+		entities:     entities,
+		tfidf:        tfidfIndex,
+		bySourceType: make(map[string]map[string][]int),
+		nameTokens:   make(map[string][]int),
+		exactNames:   make(map[string][]int),
+		cryptoKeys:   make(map[string][]int),
+	}
+
+	tfidfEnabled := tfidfIndex != nil && tfidfIndex.Enabled()
+
+	for i := range entities {
+		e := &entities[i]
+
+		// Precompute TF-IDF weights once at index time
+		if tfidfEnabled {
+			e.PreparedFields.NameWeights = tfidfIndex.GetWeights(e.PreparedFields.NameFields)
+			if len(e.PreparedFields.AltNameFields) > 0 {
+				e.PreparedFields.AltNameWeights = make([][]float64, len(e.PreparedFields.AltNameFields))
+				for j := range e.PreparedFields.AltNameFields {
+					e.PreparedFields.AltNameWeights[j] = tfidfIndex.GetWeights(e.PreparedFields.AltNameFields[j])
+				}
+			}
+			if len(e.PreparedFields.HistoricalNameFields) > 0 {
+				e.PreparedFields.HistoricalNameWeights = make([][]float64, len(e.PreparedFields.HistoricalNameFields))
+				for j := range e.PreparedFields.HistoricalNameFields {
+					e.PreparedFields.HistoricalNameWeights[j] = tfidfIndex.GetWeights(e.PreparedFields.HistoricalNameFields[j])
+				}
+			}
+		}
+
+		src := string(e.Source)
+		typ := string(e.Type)
+		c.addToPartition("", "", i)
+		c.addToPartition(src, "", i)
+		c.addToPartition("", typ, i)
+		c.addToPartition(src, typ, i)
+
+		// Exact prepared name
+		if name := e.PreparedFields.Name; name != "" {
+			c.exactNames[name] = append(c.exactNames[name], i)
+		}
+
+		// Name tokens (primary, alt, historical)
+		addTokens := func(tokens []string) {
+			for _, tok := range tokens {
+				if tok == "" {
+					continue
+				}
+				c.nameTokens[tok] = append(c.nameTokens[tok], i)
+			}
+		}
+		addTokens(e.PreparedFields.NameFields)
+		for _, alt := range e.PreparedFields.AltNameFields {
+			addTokens(alt)
+		}
+		for _, hist := range e.PreparedFields.HistoricalNameFields {
+			addTokens(hist)
+		}
+
+		// Crypto addresses for exact lookup
+		for _, addr := range e.CryptoAddresses {
+			key := cryptoKey(addr.Currency, addr.Address)
+			if key != "" {
+				c.cryptoKeys[key] = append(c.cryptoKeys[key], i)
+			}
+		}
+	}
+
+	return c
+}
+
+func (c *corpus) addToPartition(source, entityType string, idx int) {
+	byType, ok := c.bySourceType[source]
+	if !ok {
+		byType = make(map[string][]int)
+		c.bySourceType[source] = byType
+	}
+	byType[entityType] = append(byType[entityType], idx)
+}
+
+func cryptoKey(currency, address string) string {
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	address = strings.TrimSpace(address)
+	if currency == "" || address == "" {
+		return ""
+	}
+	return currency + ":" + address
+}
+
+// partitionIndices returns entity indices for the given source and type filters.
+// Empty source or type means "all".
+func (c *corpus) partitionIndices(source search.SourceList, entityType search.EntityType) []int {
+	if c == nil {
+		return nil
+	}
+
+	src := string(source)
+	if source.IsRequestType() {
+		src = ""
+	}
+	typ := string(entityType)
+
+	byType := c.bySourceType[src]
+	if byType == nil {
+		// Unknown source with no in-memory partition
+		return nil
+	}
+	return byType[typ]
+}
+
+// CandidateOpts controls candidate selection.
+type CandidateOpts struct {
+	// MaxFraction is the maximum fraction of the partition that candidates may
+	// cover before falling back to the full partition. Default 0.5.
+	MaxFraction float64
+}
+
+// selectCandidates returns entities to score for the query.
+//
+// Strategy (never reduces recall below a full partition scan):
+//  1. Restrict to source/type partition.
+//  2. Exact crypto address hits short-circuit to those entities.
+//  3. Name-token inverted index: union of postings for query name tokens,
+//     intersected with the partition. If empty or too large, use full partition.
+//  4. Identifier-only / empty-name queries use the full partition.
+func (c *corpus) selectCandidates(query search.Entity[search.Value], opts CandidateOpts) []search.Entity[search.Value] {
+	if c == nil || len(c.entities) == 0 {
+		return nil
+	}
+
+	if opts.MaxFraction <= 0 || opts.MaxFraction > 1 {
+		opts.MaxFraction = 0.5
+	}
+
+	partition := c.partitionIndices(query.Source, query.Type)
+	if partition == nil {
+		// Fall back to scanning everything when partitions missing
+		return c.entities
+	}
+	if len(partition) == 0 {
+		return nil
+	}
+
+	// Crypto exact-address fast path
+	if len(query.CryptoAddresses) > 0 {
+		partSet := partitionSet(partition)
+		var hits []int
+		seen := make(map[int]struct{})
+		for _, addr := range query.CryptoAddresses {
+			key := cryptoKey(addr.Currency, addr.Address)
+			for _, idx := range c.cryptoKeys[key] {
+				if _, inPart := partSet[idx]; !inPart {
+					continue
+				}
+				if _, ok := seen[idx]; ok {
+					continue
+				}
+				seen[idx] = struct{}{}
+				hits = append(hits, idx)
+			}
+		}
+		// Crypto-only query: return exact hits (may be empty → fall through)
+		if len(hits) > 0 && len(query.PreparedFields.NameFields) == 0 && query.PreparedFields.Name == "" {
+			return c.materialize(hits)
+		}
+		if len(hits) > 0 {
+			// Merge with name candidates so multi-field queries stay complete
+			for _, idx := range c.nameCandidateIndices(query, partition, opts) {
+				if _, ok := seen[idx]; !ok {
+					seen[idx] = struct{}{}
+					hits = append(hits, idx)
+				}
+			}
+			return c.materialize(hits)
+		}
+	}
+
+	// Name-based candidates
+	if len(query.PreparedFields.NameFields) > 0 {
+		idxs := c.nameCandidateIndices(query, partition, opts)
+		return c.materialize(idxs)
+	}
+
+	// Exact prepared name shortcut (name set but fields empty after stopwords)
+	if name := query.PreparedFields.Name; name != "" {
+		if exact := c.exactNames[name]; len(exact) > 0 {
+			filtered := intersectSorted(exact, partition)
+			if len(filtered) > 0 {
+				return c.materialize(filtered)
+			}
+		}
+	}
+
+	// Identifier / type-only / empty query: full partition
+	return c.materialize(partition)
+}
+
+func (c *corpus) nameCandidateIndices(query search.Entity[search.Value], partition []int, opts CandidateOpts) []int {
+	tokens := query.PreparedFields.NameFields
+	if len(tokens) == 0 {
+		return partition
+	}
+
+	partSet := partitionSet(partition)
+
+	// Union postings for query tokens, restricted to partition
+	seen := make(map[int]struct{})
+	var candidates []int
+	for _, tok := range tokens {
+		for _, idx := range c.nameTokens[tok] {
+			if _, inPart := partSet[idx]; !inPart {
+				continue
+			}
+			if _, ok := seen[idx]; ok {
+				continue
+			}
+			seen[idx] = struct{}{}
+			candidates = append(candidates, idx)
+		}
+	}
+
+	// No token hits (e.g. pure typos) → full partition to preserve recall
+	if len(candidates) == 0 {
+		return partition
+	}
+
+	// If candidates cover too much of the partition, scoring them is no cheaper
+	maxCount := int(float64(len(partition)) * opts.MaxFraction)
+	if maxCount < 1 {
+		maxCount = 1
+	}
+	if len(candidates) > maxCount {
+		return partition
+	}
+
+	return candidates
+}
+
+func (c *corpus) materialize(idxs []int) []search.Entity[search.Value] {
+	out := make([]search.Entity[search.Value], len(idxs))
+	for i, idx := range idxs {
+		out[i] = c.entities[idx]
+	}
+	return out
+}
+
+func partitionSet(partition []int) map[int]struct{} {
+	partSet := make(map[int]struct{}, len(partition))
+	for _, idx := range partition {
+		partSet[idx] = struct{}{}
+	}
+	return partSet
+}
+
+// intersectSorted returns intersection of two ascending slices.
+func intersectSorted(a, b []int) []int {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	var out []int
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i] == b[j] {
+			out = append(out, a[i])
+			i++
+			j++
+		} else if a[i] < b[j] {
+			i++
+		} else {
+			j++
+		}
+	}
+	return out
+}

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -65,10 +65,19 @@ func buildCorpus(entities []search.Entity[search.Value], tfidfIndex *tfidf.Index
 
 		src := string(e.Source)
 		typ := string(e.Type)
+		// Always index under the "all sources / all types" key once.
+		// Only add more specific keys when they are non-empty so empty Source/Type
+		// does not append the same entity index multiple times to one partition.
 		c.addToPartition("", "", i)
-		c.addToPartition(src, "", i)
-		c.addToPartition("", typ, i)
-		c.addToPartition(src, typ, i)
+		if src != "" {
+			c.addToPartition(src, "", i)
+		}
+		if typ != "" {
+			c.addToPartition("", typ, i)
+		}
+		if src != "" && typ != "" {
+			c.addToPartition(src, typ, i)
+		}
 
 		// Exact prepared name
 		if name := e.PreparedFields.Name; name != "" {
@@ -199,16 +208,16 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 				hits = append(hits, idx)
 			}
 		}
-		// Crypto-only query: return exact hits (may be empty → fall through)
-		if len(hits) > 0 && len(query.PreparedFields.NameFields) == 0 && query.PreparedFields.Name == "" {
-			return c.materialize(hits)
-		}
 		if len(hits) > 0 {
-			// Merge with name candidates so multi-field queries stay complete
-			for _, idx := range c.nameCandidateIndices(query, partition, opts) {
-				if _, ok := seen[idx]; !ok {
-					seen[idx] = struct{}{}
-					hits = append(hits, idx)
+			// Merge name candidates only when the query has name tokens.
+			// Otherwise nameCandidateIndices returns the full partition and would
+			// defeat the crypto exact-address fast path.
+			if len(query.PreparedFields.NameFields) > 0 {
+				for _, idx := range c.nameCandidateIndices(query, partition, opts) {
+					if _, ok := seen[idx]; !ok {
+						seen[idx] = struct{}{}
+						hits = append(hits, idx)
+					}
 				}
 			}
 			return c.materialize(hits)

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -75,12 +75,17 @@ func buildCorpus(entities []search.Entity[search.Value], tfidfIndex *tfidf.Index
 			c.exactNames[name] = append(c.exactNames[name], i)
 		}
 
-		// Name tokens (primary, alt, historical)
+		// Name tokens (primary, alt, historical) — one posting per token per entity
+		seenTokens := make(map[string]struct{})
 		addTokens := func(tokens []string) {
 			for _, tok := range tokens {
 				if tok == "" {
 					continue
 				}
+				if _, dup := seenTokens[tok]; dup {
+					continue
+				}
+				seenTokens[tok] = struct{}{}
 				c.nameTokens[tok] = append(c.nameTokens[tok], i)
 			}
 		}

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -203,19 +203,13 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 	// Crypto exact-address fast path
 	if len(query.CryptoAddresses) > 0 {
 		var hits []int
-		seen := make(map[int]struct{})
 		for _, addr := range query.CryptoAddresses {
 			key := cryptoKey(addr.Currency, addr.Address)
 			for _, idx := range c.cryptoKeys[key] {
 				// partition is sorted ascending (built by appending increasing indices)
-				if _, found := slices.BinarySearch(partition, idx); !found {
-					continue
+				if _, found := slices.BinarySearch(partition, idx); found {
+					hits = append(hits, idx)
 				}
-				if _, ok := seen[idx]; ok {
-					continue
-				}
-				seen[idx] = struct{}{}
-				hits = append(hits, idx)
 			}
 		}
 		if len(hits) > 0 {
@@ -223,13 +217,10 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 			// Otherwise nameCandidateIndices returns the full partition and would
 			// defeat the crypto exact-address fast path.
 			if len(query.PreparedFields.NameFields) > 0 {
-				for _, idx := range c.nameCandidateIndices(query, partition, opts) {
-					if _, ok := seen[idx]; !ok {
-						seen[idx] = struct{}{}
-						hits = append(hits, idx)
-					}
-				}
+				hits = append(hits, c.nameCandidateIndices(query, partition, opts)...)
 			}
+			slices.Sort(hits)
+			hits = slices.Compact(hits)
 			return c.materialize(hits)
 		}
 	}
@@ -261,19 +252,13 @@ func (c *corpus) nameCandidateIndices(query search.Entity[search.Value], partiti
 	}
 
 	// Union postings for query tokens, restricted to partition.
-	// Membership uses binary search over the sorted partition (no map alloc per query).
-	seen := make(map[int]struct{})
+	// Deduplicate with sort+compact instead of a per-query seen map.
 	var candidates []int
 	for _, tok := range tokens {
 		for _, idx := range c.nameTokens[tok] {
-			if _, found := slices.BinarySearch(partition, idx); !found {
-				continue
+			if _, found := slices.BinarySearch(partition, idx); found {
+				candidates = append(candidates, idx)
 			}
-			if _, ok := seen[idx]; ok {
-				continue
-			}
-			seen[idx] = struct{}{}
-			candidates = append(candidates, idx)
 		}
 	}
 
@@ -281,6 +266,9 @@ func (c *corpus) nameCandidateIndices(query search.Entity[search.Value], partiti
 	if len(candidates) == 0 {
 		return partition
 	}
+
+	slices.Sort(candidates)
+	candidates = slices.Compact(candidates)
 
 	// If candidates cover too much of the partition, scoring them is no cheaper
 	maxCount := int(float64(len(partition)) * opts.MaxFraction)

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -138,9 +138,13 @@ func cryptoKey(currency, address string) string {
 
 // partitionIndices returns entity indices for the given source and type filters.
 // Empty source or type means "all".
-func (c *corpus) partitionIndices(source search.SourceList, entityType search.EntityType) []int {
+//
+// The bool is true when the source key exists in the corpus (even if the type
+// slice is empty). Callers must distinguish "unknown source" from "known source,
+// zero entities of this type" so they do not fall back to a full corpus scan.
+func (c *corpus) partitionIndices(source search.SourceList, entityType search.EntityType) ([]int, bool) {
 	if c == nil {
-		return nil
+		return nil, false
 	}
 
 	src := string(source)
@@ -149,12 +153,17 @@ func (c *corpus) partitionIndices(source search.SourceList, entityType search.En
 	}
 	typ := string(entityType)
 
-	byType := c.bySourceType[src]
-	if byType == nil {
+	byType, ok := c.bySourceType[src]
+	if !ok {
 		// Unknown source with no in-memory partition
-		return nil
+		return nil, false
 	}
-	return byType[typ]
+	// Missing type key means an empty partition for that type, not an unknown source.
+	idxs, _ := byType[typ]
+	if idxs == nil {
+		return []int{}, true
+	}
+	return idxs, true
 }
 
 // CandidateOpts controls candidate selection.
@@ -181,12 +190,13 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 		opts.MaxFraction = 0.5
 	}
 
-	partition := c.partitionIndices(query.Source, query.Type)
-	if partition == nil {
-		// Fall back to scanning everything when partitions missing
-		return c.entities
+	partition, sourceOK := c.partitionIndices(query.Source, query.Type)
+	if !sourceOK {
+		// Unknown source key: do not scan unrelated lists
+		return nil
 	}
 	if len(partition) == 0 {
+		// Known source (or all-sources) but no entities of this type
 		return nil
 	}
 

--- a/internal/index/corpus.go
+++ b/internal/index/corpus.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/moov-io/watchman/internal/tfidf"
@@ -177,13 +178,13 @@ func (c *corpus) selectCandidates(query search.Entity[search.Value], opts Candid
 
 	// Crypto exact-address fast path
 	if len(query.CryptoAddresses) > 0 {
-		partSet := partitionSet(partition)
 		var hits []int
 		seen := make(map[int]struct{})
 		for _, addr := range query.CryptoAddresses {
 			key := cryptoKey(addr.Currency, addr.Address)
 			for _, idx := range c.cryptoKeys[key] {
-				if _, inPart := partSet[idx]; !inPart {
+				// partition is sorted ascending (built by appending increasing indices)
+				if _, found := slices.BinarySearch(partition, idx); !found {
 					continue
 				}
 				if _, ok := seen[idx]; ok {
@@ -235,14 +236,13 @@ func (c *corpus) nameCandidateIndices(query search.Entity[search.Value], partiti
 		return partition
 	}
 
-	partSet := partitionSet(partition)
-
-	// Union postings for query tokens, restricted to partition
+	// Union postings for query tokens, restricted to partition.
+	// Membership uses binary search over the sorted partition (no map alloc per query).
 	seen := make(map[int]struct{})
 	var candidates []int
 	for _, tok := range tokens {
 		for _, idx := range c.nameTokens[tok] {
-			if _, inPart := partSet[idx]; !inPart {
+			if _, found := slices.BinarySearch(partition, idx); !found {
 				continue
 			}
 			if _, ok := seen[idx]; ok {
@@ -276,14 +276,6 @@ func (c *corpus) materialize(idxs []int) []search.Entity[search.Value] {
 		out[i] = c.entities[idx]
 	}
 	return out
-}
-
-func partitionSet(partition []int) map[int]struct{} {
-	partSet := make(map[int]struct{}, len(partition))
-	for _, idx := range partition {
-		partSet[idx] = struct{}{}
-	}
-	return partSet
 }
 
 // intersectSorted returns intersection of two ascending slices.

--- a/internal/index/corpus_test.go
+++ b/internal/index/corpus_test.go
@@ -1,0 +1,106 @@
+package index
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorpus_PartitionAndCandidates(t *testing.T) {
+	entities := []search.Entity[search.Value]{
+		mustNorm(search.Entity[search.Value]{
+			Name:     "John Smith",
+			Type:     search.EntityPerson,
+			Source:   search.SourceUSOFAC,
+			SourceID: "1",
+			Person:   &search.Person{Name: "John Smith"},
+		}),
+		mustNorm(search.Entity[search.Value]{
+			Name:     "Acme Shipping Limited",
+			Type:     search.EntityBusiness,
+			Source:   search.SourceUSOFAC,
+			SourceID: "2",
+			Business: &search.Business{Name: "Acme Shipping Limited"},
+		}),
+		mustNorm(search.Entity[search.Value]{
+			Name:     "Other Corp",
+			Type:     search.EntityBusiness,
+			Source:   search.SourceEUCSL,
+			SourceID: "3",
+			Business: &search.Business{Name: "Other Corp"},
+			CryptoAddresses: []search.CryptoAddress{
+				{Currency: "XBT", Address: "abc123"},
+			},
+		}),
+	}
+
+	lists := NewLists(nil)
+	lists.Update(download.Stats{
+		Entities: entities,
+		Lists: map[string]int{
+			string(search.SourceUSOFAC): 2,
+			string(search.SourceEUCSL):  1,
+		},
+	})
+
+	ctx := context.Background()
+
+	t.Run("GetEntities by source", func(t *testing.T) {
+		got, err := lists.GetEntities(ctx, search.SourceUSOFAC)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+	})
+
+	t.Run("type partition via candidates", func(t *testing.T) {
+		query := mustNorm(search.Entity[search.Value]{
+			Name:   "Shipping Limited",
+			Type:   search.EntityBusiness,
+			Source: search.SourceUSOFAC,
+		})
+		cands, err := lists.SelectCandidates(ctx, query)
+		require.NoError(t, err)
+		// Should not include the person or EU entity
+		require.NotEmpty(t, cands)
+		for _, c := range cands {
+			require.Equal(t, search.EntityBusiness, c.Type)
+			require.Equal(t, search.SourceUSOFAC, c.Source)
+		}
+		// Token "shipping" should hit entity 2
+		require.True(t, len(cands) <= 2)
+	})
+
+	t.Run("crypto exact candidate", func(t *testing.T) {
+		query := mustNorm(search.Entity[search.Value]{
+			Type: search.EntityBusiness,
+			CryptoAddresses: []search.CryptoAddress{
+				{Currency: "XBT", Address: "abc123"},
+			},
+		})
+		// empty source → all sources partition
+		cands, err := lists.SelectCandidates(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, cands, 1)
+		require.Equal(t, "3", cands[0].SourceID)
+	})
+
+	t.Run("typo falls back to partition", func(t *testing.T) {
+		query := mustNorm(search.Entity[search.Value]{
+			Name:   "Zzznotatoken",
+			Type:   search.EntityPerson,
+			Source: search.SourceUSOFAC,
+		})
+		cands, err := lists.SelectCandidates(ctx, query)
+		require.NoError(t, err)
+		// Full person partition for US OFAC
+		require.Len(t, cands, 1)
+		require.Equal(t, "1", cands[0].SourceID)
+	})
+}
+
+func mustNorm(e search.Entity[search.Value]) search.Entity[search.Value] {
+	return e.Normalize()
+}

--- a/internal/index/corpus_test.go
+++ b/internal/index/corpus_test.go
@@ -116,6 +116,39 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 		require.Empty(t, got, "empty source partition must not fall back to all entities")
 	})
 
+	t.Run("empty source/type does not duplicate all-partition entries", func(t *testing.T) {
+		bare := mustNorm(search.Entity[search.Value]{
+			Name:     "Bare Entity",
+			SourceID: "bare",
+			// Source and Type intentionally empty
+		})
+		idx.Update(download.Stats{
+			Entities: []search.Entity[search.Value]{bare},
+			Lists:    map[string]int{"": 1},
+		})
+		impl := idx.(*lists)
+		impl.mu.RLock()
+		all := impl.corpus.bySourceType[""][""]
+		impl.mu.RUnlock()
+		require.Equal(t, []int{0}, all, "empty source/type must append entity once to all-partition")
+	})
+
+	t.Run("crypto without name tokens does not expand to full partition", func(t *testing.T) {
+		idx.Update(stats) // restore multi-entity corpus
+		query := mustNorm(search.Entity[search.Value]{
+			// No name — only crypto. Must not expand to full business partition.
+			Type: search.EntityBusiness,
+			CryptoAddresses: []search.CryptoAddress{
+				{Currency: "XBT", Address: "abc123"},
+			},
+		})
+		require.Empty(t, query.PreparedFields.NameFields)
+		cands, err := idx.SelectCandidates(ctx, query)
+		require.NoError(t, err)
+		require.Len(t, cands, 1)
+		require.Equal(t, "3", cands[0].SourceID)
+	})
+
 	t.Run("name tokens deduped per entity", func(t *testing.T) {
 		// Rebuild with an entity that repeats a token across primary and alt names
 		dup := mustNorm(search.Entity[search.Value]{

--- a/internal/index/corpus_test.go
+++ b/internal/index/corpus_test.go
@@ -101,6 +101,18 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 		require.Equal(t, "1", cands[0].SourceID)
 	})
 
+	t.Run("empty type within known source does not scan full corpus", func(t *testing.T) {
+		// US OFAC has persons and businesses but no aircraft
+		query := mustNorm(search.Entity[search.Value]{
+			Name:   "Anything",
+			Type:   search.EntityAircraft,
+			Source: search.SourceUSOFAC,
+		})
+		cands, err := idx.SelectCandidates(ctx, query)
+		require.NoError(t, err)
+		require.Empty(t, cands, "empty type partition must not fall back to scoring all entities")
+	})
+
 	t.Run("GetEntities empty partition does not leak other sources", func(t *testing.T) {
 		// Source is registered in Lists but has no entities in the corpus
 		idx.Update(download.Stats{

--- a/internal/index/corpus_test.go
+++ b/internal/index/corpus_test.go
@@ -38,19 +38,20 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 		}),
 	}
 
-	lists := NewLists(nil)
-	lists.Update(download.Stats{
+	stats := download.Stats{
 		Entities: entities,
 		Lists: map[string]int{
 			string(search.SourceUSOFAC): 2,
 			string(search.SourceEUCSL):  1,
 		},
-	})
+	}
 
+	idx := NewLists(nil)
+	idx.Update(stats)
 	ctx := context.Background()
 
 	t.Run("GetEntities by source", func(t *testing.T) {
-		got, err := lists.GetEntities(ctx, search.SourceUSOFAC)
+		got, err := idx.GetEntities(ctx, search.SourceUSOFAC)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
 	})
@@ -61,7 +62,7 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 			Type:   search.EntityBusiness,
 			Source: search.SourceUSOFAC,
 		})
-		cands, err := lists.SelectCandidates(ctx, query)
+		cands, err := idx.SelectCandidates(ctx, query)
 		require.NoError(t, err)
 		// Should not include the person or EU entity
 		require.NotEmpty(t, cands)
@@ -81,7 +82,7 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 			},
 		})
 		// empty source → all sources partition
-		cands, err := lists.SelectCandidates(ctx, query)
+		cands, err := idx.SelectCandidates(ctx, query)
 		require.NoError(t, err)
 		require.Len(t, cands, 1)
 		require.Equal(t, "3", cands[0].SourceID)
@@ -93,11 +94,58 @@ func TestCorpus_PartitionAndCandidates(t *testing.T) {
 			Type:   search.EntityPerson,
 			Source: search.SourceUSOFAC,
 		})
-		cands, err := lists.SelectCandidates(ctx, query)
+		cands, err := idx.SelectCandidates(ctx, query)
 		require.NoError(t, err)
 		// Full person partition for US OFAC
 		require.Len(t, cands, 1)
 		require.Equal(t, "1", cands[0].SourceID)
+	})
+
+	t.Run("GetEntities empty partition does not leak other sources", func(t *testing.T) {
+		// Source is registered in Lists but has no entities in the corpus
+		idx.Update(download.Stats{
+			Entities: entities,
+			Lists: map[string]int{
+				string(search.SourceUSOFAC): 2,
+				string(search.SourceEUCSL):  1,
+				string(search.SourceUKCSL):  0, // listed but empty
+			},
+		})
+		got, err := idx.GetEntities(ctx, search.SourceUKCSL)
+		require.NoError(t, err)
+		require.Empty(t, got, "empty source partition must not fall back to all entities")
+	})
+
+	t.Run("name tokens deduped per entity", func(t *testing.T) {
+		// Rebuild with an entity that repeats a token across primary and alt names
+		dup := mustNorm(search.Entity[search.Value]{
+			Name:     "Smith Trading Smith",
+			Type:     search.EntityBusiness,
+			Source:   search.SourceUSOFAC,
+			SourceID: "dup",
+			Business: &search.Business{
+				Name:     "Smith Trading Smith",
+				AltNames: []string{"Smith Holdings"},
+			},
+		})
+		idx.Update(download.Stats{
+			Entities: []search.Entity[search.Value]{dup},
+			Lists:    map[string]int{string(search.SourceUSOFAC): 1},
+		})
+
+		cands, err := idx.SelectCandidates(ctx, mustNorm(search.Entity[search.Value]{
+			Name:   "Smith",
+			Type:   search.EntityBusiness,
+			Source: search.SourceUSOFAC,
+		}))
+		require.NoError(t, err)
+		require.Len(t, cands, 1)
+
+		impl := idx.(*lists)
+		impl.mu.RLock()
+		postings := impl.corpus.nameTokens["smith"]
+		impl.mu.RUnlock()
+		require.Equal(t, []int{0}, postings, "entity index should appear once per token")
 	})
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -14,6 +14,10 @@ import (
 
 type Lists interface {
 	GetEntities(ctx context.Context, source search.SourceList) ([]search.Entity[search.Value], error)
+	// SelectCandidates returns the subset of entities that should be scored for the query.
+	// It applies source/type partitioning and name/crypto inverted indexes, with safe
+	// fallbacks that never reduce recall below a full partition scan.
+	SelectCandidates(ctx context.Context, query search.Entity[search.Value]) ([]search.Entity[search.Value], error)
 	Update(latest download.Stats)
 	LatestStats() download.Stats
 	GetTFIDFIndex() *tfidf.Index
@@ -28,6 +32,7 @@ func NewLists(ingestRepository ingest.Repository) Lists {
 type lists struct {
 	mu          sync.RWMutex
 	latestStats download.Stats
+	corpus      *corpus
 
 	ingestRepository ingest.Repository
 }
@@ -45,6 +50,16 @@ func (l *lists) GetEntities(ctx context.Context, source search.SourceList) ([]se
 	}
 
 	if exists {
+		if l.corpus != nil {
+			// Prefer partitioned view when a specific source is requested
+			if src := string(source); src != "" && !source.IsRequestType() {
+				idxs := l.corpus.partitionIndices(source, "")
+				if len(idxs) > 0 {
+					return l.corpus.materialize(idxs), nil
+				}
+			}
+			return l.corpus.entities, nil
+		}
 		return l.latestStats.Entities, nil
 	}
 
@@ -52,6 +67,31 @@ func (l *lists) GetEntities(ctx context.Context, source search.SourceList) ([]se
 	if l.ingestRepository != nil {
 		// TODO(adam): need to support pagination
 		return l.ingestRepository.ListBySource(ctx, "", source, 1000)
+	}
+
+	return nil, fmt.Errorf("source %s not found", source)
+}
+
+func (l *lists) SelectCandidates(ctx context.Context, query search.Entity[search.Value]) ([]search.Entity[search.Value], error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	source := query.Source
+	_, exists := l.latestStats.Lists[string(source)]
+	exists = exists || source.IsRequestType() || string(source) == ""
+
+	if exists && l.corpus != nil {
+		return l.corpus.selectCandidates(query, CandidateOpts{}), nil
+	}
+
+	// Ingested-only source: pull from repository and return as-is (no inverted index)
+	if !exists && l.ingestRepository != nil {
+		return l.ingestRepository.ListBySource(ctx, "", source, 1000)
+	}
+
+	if exists {
+		// Corpus not built yet — return full list
+		return l.latestStats.Entities, nil
 	}
 
 	return nil, fmt.Errorf("source %s not found", source)
@@ -73,15 +113,22 @@ func (l *lists) LatestStats() download.Stats {
 }
 
 func (l *lists) Update(latest download.Stats) {
+	// Build search corpus outside the write lock (CPU-heavy)
+	c := buildCorpus(latest.Entities, latest.TFIDFIndex)
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	l.latestStats = latest
+	l.corpus = c
 }
 
 func (l *lists) GetTFIDFIndex() *tfidf.Index {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 
+	if l.corpus != nil {
+		return l.corpus.tfidf
+	}
 	return l.latestStats.TFIDFIndex
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -55,7 +55,7 @@ func (l *lists) GetEntities(ctx context.Context, source search.SourceList) ([]se
 			// Always return the partition (even if empty) so we never leak entities
 			// from other sources when the requested partition has no rows.
 			if src := string(source); src != "" && !source.IsRequestType() {
-				idxs := l.corpus.partitionIndices(source, "")
+				idxs, _ := l.corpus.partitionIndices(source, "")
 				return l.corpus.materialize(idxs), nil
 			}
 			return l.corpus.entities, nil

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -51,12 +51,12 @@ func (l *lists) GetEntities(ctx context.Context, source search.SourceList) ([]se
 
 	if exists {
 		if l.corpus != nil {
-			// Prefer partitioned view when a specific source is requested
+			// Prefer partitioned view when a specific source is requested.
+			// Always return the partition (even if empty) so we never leak entities
+			// from other sources when the requested partition has no rows.
 			if src := string(source); src != "" && !source.IsRequestType() {
 				idxs := l.corpus.partitionIndices(source, "")
-				if len(idxs) > 0 {
-					return l.corpus.materialize(idxs), nil
-				}
+				return l.corpus.materialize(idxs), nil
 			}
 			return l.corpus.entities, nil
 		}

--- a/internal/largest/items.go
+++ b/internal/largest/items.go
@@ -53,7 +53,29 @@ func (xs *Items[T]) Add(it Item[T]) {
 
 	xs.mu.Lock()
 	defer xs.mu.Unlock()
+	xs.addLocked(it)
+}
 
+// AddLocal is like Add but without locking. Safe only when a single goroutine
+// owns the Items instance (e.g. a per-worker local top-K buffer).
+func (xs *Items[T]) AddLocal(it Item[T]) {
+	if it.Weight < xs.minMatch {
+		return
+	}
+	xs.addLocked(it)
+}
+
+// Merge incorporates all items from other into xs.
+func (xs *Items[T]) Merge(other *Items[T]) {
+	if other == nil {
+		return
+	}
+	for _, it := range other.Items() {
+		xs.Add(it)
+	}
+}
+
+func (xs *Items[T]) addLocked(it Item[T]) {
 	// If there's room, just insert in the correct spot
 	if len(xs.items) < xs.capacity {
 		xs.insertDescending(it)

--- a/internal/search/config.go
+++ b/internal/search/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/moov-io/watchman/internal/embeddings"
 )
@@ -12,6 +13,10 @@ import (
 type Config struct {
 	Goroutines Goroutines
 	Embeddings embeddings.Config
+
+	// MaxInFlight bounds concurrent full-list searches (admission control).
+	// Zero means GOMAXPROCS. Override with SEARCH_MAX_IN_FLIGHT.
+	MaxInFlight int
 }
 
 type Goroutines struct {
@@ -28,12 +33,20 @@ func DefaultConfig() Config {
 		cpus = cmp.Or(cpus, int(n))
 	}
 
+	inFlight := runtime.GOMAXPROCS(0)
+	if v := strings.TrimSpace(os.Getenv("SEARCH_MAX_IN_FLIGHT")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			inFlight = n
+		}
+	}
+
 	return Config{
 		Goroutines: Goroutines{
 			Default: cpus * 2,
 			Min:     cpus,
 			Max:     cpus * 4,
 		},
-		Embeddings: embeddings.DefaultConfig(),
+		Embeddings:  embeddings.DefaultConfig(),
+		MaxInFlight: inFlight,
 	}
 }

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -32,6 +32,11 @@ import (
 // to account for filtering (by type, threshold, etc.) before returning final results.
 const embeddingSearchLimitMultiplier = 2
 
+// smallCandidateBypass is the max candidate-set size that skips the search admission
+// semaphore. Exact crypto/ID hits and tightly pruned name queries stay off the queue
+// so they are not blocked behind full-partition scans.
+const smallCandidateBypass = 100
+
 type Service interface {
 	LatestStats() download.Stats
 
@@ -223,17 +228,28 @@ type debugRespone struct {
 }
 
 func (s *service) performSearch(ctx context.Context, query search.Entity[search.Value], opts SearchOpts) ([]search.SearchedEntity[search.Value], error) {
-	// Admission control: bound concurrent full scans so worker pools do not oversubscribe CPUs
-	select {
-	case s.searchSem <- struct{}{}:
-		defer func() { <-s.searchSem }()
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	// Candidate selection first (cheap, RLock only) so we can skip admission control
+	// for tiny result sets and avoid queuing them behind full-partition scans.
+	searchEntities, err := s.indexedLists.SelectCandidates(ctx, query)
+	if err != nil {
+		s.logger.Error().Logf("selecting candidate entities failed: %v", err)
+		return nil, fmt.Errorf("selecting candidate entities: %w", err)
+	}
+
+	// Admission control: bound concurrent large scans so worker pools do not oversubscribe CPUs.
+	if len(searchEntities) > smallCandidateBypass {
+		select {
+		case s.searchSem <- struct{}{}:
+			defer func() { <-s.searchSem }()
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	_, span := telemetry.StartSpan(ctx, "perform-search", trace.WithAttributes(
 		attribute.Int("opts.limit", opts.Limit),
 		attribute.Float64("opts.min_match", opts.MinMatch),
+		attribute.Int("index.candidate_count", len(searchEntities)),
 	))
 	defer span.End()
 
@@ -243,13 +259,6 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 		return nil, fmt.Errorf("getGoroutineCount: %w", err)
 	}
 	start := time.Now()
-
-	// Candidate selection: source/type partition + token/crypto inverted indexes
-	searchEntities, err := s.indexedLists.SelectCandidates(ctx, query)
-	if err != nil {
-		s.logger.Error().Logf("selecting candidate entities failed: %v", err)
-		return nil, fmt.Errorf("selecting candidate entities: %w", err)
-	}
 
 	// Precompute query term weights once per search when TF-IDF is enabled
 	tfidfIndex := s.indexedLists.GetTFIDFIndex()
@@ -381,8 +390,9 @@ func scoreEntities(
 ) {
 	for i := range entities {
 		indexEntity := entities[i]
+		isDebugEntity := hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID)
 
-		if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+		if isDebugEntity {
 			logger.Debug().With(log.Fields{
 				"debug_source_id": log.String(indexEntity.SourceID),
 			}).Logf("indexed entity: %#v", indexEntity)
@@ -398,7 +408,7 @@ func scoreEntities(
 			scores := search.DebugSimilarityWithTFIDF(&buf, query, indexEntity, tfidfIndex)
 			score = scores.FinalScore
 
-			if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+			if isDebugEntity {
 				logger.Debug().With(log.Fields{
 					"debug_source_id": log.String(indexEntity.SourceID),
 				}).Logf("similarity score: %#v", scores)
@@ -419,7 +429,7 @@ func scoreEntities(
 			}
 		}
 
-		if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+		if isDebugEntity {
 			logger.Debug().With(log.Fields{
 				"debug_source_id": log.String(indexEntity.SourceID),
 			}).Logf("final score: %.5f", score)

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -274,30 +274,29 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 		numWorkers = 1
 	}
 
-	// Per-worker local top-K (no shared mutex on the hot path), then merge
-	localItems := make([]*largest.Items[search.Entity[search.Value]], numWorkers)
-	var localDebugs []*largest.Items[debugRespone]
+	items := largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
+	var debugs *largest.Items[debugRespone]
 	if opts.Debug {
-		localDebugs = make([]*largest.Items[debugRespone], numWorkers)
-	}
-	for i := 0; i < numWorkers; i++ {
-		localItems[i] = largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
-		if opts.Debug {
-			localDebugs[i] = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
-		}
-	}
-
-	score := func(w int, entities []search.Entity[search.Value]) {
-		var debugLocal *largest.Items[debugRespone]
-		if opts.Debug {
-			debugLocal = localDebugs[w]
-		}
-		scoreEntities(entities, query, tfidfIndex, opts, hasDebugIDs, s.logger, localItems[w], debugLocal)
+		debugs = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
 	}
 
 	if numWorkers <= 1 {
-		score(0, searchEntities)
+		// Common path after candidate pruning: score directly, no local heaps/merge.
+		scoreEntities(searchEntities, query, tfidfIndex, opts, hasDebugIDs, s.logger, items, debugs)
 	} else {
+		// Per-worker local top-K (no shared mutex on the hot path), then merge
+		localItems := make([]*largest.Items[search.Entity[search.Value]], numWorkers)
+		var localDebugs []*largest.Items[debugRespone]
+		if opts.Debug {
+			localDebugs = make([]*largest.Items[debugRespone], numWorkers)
+		}
+		for i := 0; i < numWorkers; i++ {
+			localItems[i] = largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
+			if opts.Debug {
+				localDebugs[i] = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
+			}
+		}
+
 		chunkSize := (len(searchEntities) + numWorkers - 1) / numWorkers
 		var wg sync.WaitGroup
 		for worker := 0; worker < numWorkers; worker++ {
@@ -312,22 +311,20 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 			wg.Add(1)
 			go func(w, start, end int) {
 				defer wg.Done()
-				score(w, searchEntities[start:end])
+				var debugLocal *largest.Items[debugRespone]
+				if opts.Debug {
+					debugLocal = localDebugs[w]
+				}
+				scoreEntities(searchEntities[start:end], query, tfidfIndex, opts, hasDebugIDs, s.logger, localItems[w], debugLocal)
 			}(worker, startIdx, endIdx)
 		}
 		wg.Wait()
-	}
 
-	// Merge local top-K into final results
-	items := largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
-	var debugs *largest.Items[debugRespone]
-	if opts.Debug {
-		debugs = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
-	}
-	for i := range localItems {
-		items.Merge(localItems[i])
-		if opts.Debug {
-			debugs.Merge(localDebugs[i])
+		for i := range localItems {
+			items.Merge(localItems[i])
+			if opts.Debug {
+				debugs.Merge(localDebugs[i])
+			}
 		}
 	}
 

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -265,16 +265,22 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 		}
 	}
 
-	// Per-worker local top-K (no shared mutex on the hot path), then merge
+	// Size the worker pool to the candidate set — pruning often leaves few entities.
 	if goroutineCount < 1 {
 		goroutineCount = 1
 	}
-	localItems := make([]*largest.Items[search.Entity[search.Value]], goroutineCount)
+	numWorkers := goroutineCount
+	if numWorkers <= 1 || len(searchEntities) < numWorkers {
+		numWorkers = 1
+	}
+
+	// Per-worker local top-K (no shared mutex on the hot path), then merge
+	localItems := make([]*largest.Items[search.Entity[search.Value]], numWorkers)
 	var localDebugs []*largest.Items[debugRespone]
 	if opts.Debug {
-		localDebugs = make([]*largest.Items[debugRespone], goroutineCount)
+		localDebugs = make([]*largest.Items[debugRespone], numWorkers)
 	}
-	for i := 0; i < goroutineCount; i++ {
+	for i := 0; i < numWorkers; i++ {
 		localItems[i] = largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
 		if opts.Debug {
 			localDebugs[i] = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
@@ -289,27 +295,25 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 		scoreEntities(entities, query, tfidfIndex, opts, hasDebugIDs, s.logger, localItems[w], debugLocal)
 	}
 
-	if goroutineCount <= 1 || len(searchEntities) < goroutineCount {
+	if numWorkers <= 1 {
 		score(0, searchEntities)
 	} else {
-		chunkSize := (len(searchEntities) + goroutineCount - 1) / goroutineCount
+		chunkSize := (len(searchEntities) + numWorkers - 1) / numWorkers
 		var wg sync.WaitGroup
-		worker := 0
-		for startIdx := 0; startIdx < len(searchEntities); startIdx += chunkSize {
+		for worker := 0; worker < numWorkers; worker++ {
+			startIdx := worker * chunkSize
+			if startIdx >= len(searchEntities) {
+				break
+			}
 			endIdx := startIdx + chunkSize
 			if endIdx > len(searchEntities) {
 				endIdx = len(searchEntities)
 			}
-			w := worker
-			if w >= goroutineCount {
-				w = goroutineCount - 1
-			}
 			wg.Add(1)
-			go func(w, startIdx, endIdx int) {
+			go func(w, start, end int) {
 				defer wg.Done()
-				score(w, searchEntities[startIdx:endIdx])
-			}(w, startIdx, endIdx)
-			worker++
+				score(w, searchEntities[start:end])
+			}(worker, startIdx, endIdx)
 		}
 		wg.Wait()
 	}
@@ -328,11 +332,11 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 	}
 
 	diff := time.Since(start)
-	s.cm.RecordDuration(goroutineCount, diff)
+	s.cm.RecordDuration(numWorkers, diff)
 
 	span.SetAttributes(
 		attribute.Int("index.searched_entities", len(searchEntities)),
-		attribute.Int("search.goroutine_count", goroutineCount),
+		attribute.Int("search.goroutine_count", numWorkers),
 		attribute.Int64("search.duration", diff.Milliseconds()),
 	)
 

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -6,9 +6,11 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/moov-io/watchman/internal/concurrencychamp"
@@ -16,9 +18,8 @@ import (
 	"github.com/moov-io/watchman/internal/download"
 	"github.com/moov-io/watchman/internal/embeddings"
 	"github.com/moov-io/watchman/internal/index"
-	"github.com/moov-io/watchman/internal/indices"
 	"github.com/moov-io/watchman/internal/largest"
-	"github.com/moov-io/watchman/internal/minmaxmed"
+	"github.com/moov-io/watchman/internal/tfidf"
 	"github.com/moov-io/watchman/pkg/search"
 
 	"github.com/moov-io/base/log"
@@ -56,12 +57,21 @@ func NewService(logger log.Logger, config Config, database db.DB, indexedLists i
 		}
 	}
 
+	inFlight := config.MaxInFlight
+	if inFlight <= 0 {
+		inFlight = runtime.GOMAXPROCS(0)
+		if inFlight < 1 {
+			inFlight = 1
+		}
+	}
+
 	return &service{
 		logger:       logger,
 		config:       config,
 		indexedLists: indexedLists,
 		cm:           cm,
 		embeddings:   embeddingsSvc,
+		searchSem:    make(chan struct{}, inFlight),
 	}, nil
 }
 
@@ -73,6 +83,9 @@ type service struct {
 	embeddings   embeddings.Service
 
 	cm *concurrencychamp.ConcurrencyManager
+
+	// searchSem limits concurrent full-corpus searches to avoid goroutine oversubscription
+	searchSem chan struct{}
 }
 
 func (s *service) LatestStats() download.Stats {
@@ -210,19 +223,19 @@ type debugRespone struct {
 }
 
 func (s *service) performSearch(ctx context.Context, query search.Entity[search.Value], opts SearchOpts) ([]search.SearchedEntity[search.Value], error) {
+	// Admission control: bound concurrent full scans so worker pools do not oversubscribe CPUs
+	select {
+	case s.searchSem <- struct{}{}:
+		defer func() { <-s.searchSem }()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
 	_, span := telemetry.StartSpan(ctx, "perform-search", trace.WithAttributes(
 		attribute.Int("opts.limit", opts.Limit),
 		attribute.Float64("opts.min_match", opts.MinMatch),
 	))
 	defer span.End()
-
-	stats := minmaxmed.New(10) // window size
-	items := largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
-
-	var debugs *largest.Items[debugRespone]
-	if opts.Debug {
-		debugs = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
-	}
 
 	goroutineCount, err := getGoroutineCount(s.cm)
 	if err != nil {
@@ -231,71 +244,88 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 	}
 	start := time.Now()
 
-	// Check if the query is targeting ingested files
-	searchEntities, err := s.indexedLists.GetEntities(ctx, query.Source)
+	// Candidate selection: source/type partition + token/crypto inverted indexes
+	searchEntities, err := s.indexedLists.SelectCandidates(ctx, query)
 	if err != nil {
-		s.logger.Error().Logf("getting indexed entities failed: %v", err)
-		return nil, fmt.Errorf("getting indexed entities: %w", err)
+		s.logger.Error().Logf("selecting candidate entities failed: %v", err)
+		return nil, fmt.Errorf("selecting candidate entities: %w", err)
 	}
 
-	// Get TF-IDF index for weighted name matching
+	// Precompute query term weights once per search when TF-IDF is enabled
 	tfidfIndex := s.indexedLists.GetTFIDFIndex()
+	if tfidfIndex != nil && tfidfIndex.Enabled() && len(query.PreparedFields.NameFields) > 0 {
+		query.PreparedFields.NameWeights = tfidfIndex.GetWeights(query.PreparedFields.NameFields)
+	}
 
-	indices.ProcessSliceFn(searchEntities, goroutineCount, func(index search.Entity[search.Value]) {
-		start := time.Now()
-
-		debugSourceID := slices.Contains(opts.DebugSourceIDs, index.SourceID)
-
-		if debugSourceID {
-			s.logger.Debug().With(log.Fields{
-				"debug_source_id": log.String(index.SourceID),
-			}).Logf("indexed entity: %#v", index)
+	hasDebugIDs := false
+	for _, id := range opts.DebugSourceIDs {
+		if id != "" {
+			hasDebugIDs = true
+			break
 		}
+	}
 
-		var score float64
-		if !opts.Debug {
-			score = search.SimilarityWithTFIDF(query, index, tfidfIndex)
-		} else {
-			var buf bytes.Buffer
-			buf.Grow(1700) // approximate size of debug logs
+	// Per-worker local top-K (no shared mutex on the hot path), then merge
+	if goroutineCount < 1 {
+		goroutineCount = 1
+	}
+	localItems := make([]*largest.Items[search.Entity[search.Value]], goroutineCount)
+	var localDebugs []*largest.Items[debugRespone]
+	if opts.Debug {
+		localDebugs = make([]*largest.Items[debugRespone], goroutineCount)
+	}
+	for i := 0; i < goroutineCount; i++ {
+		localItems[i] = largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
+		if opts.Debug {
+			localDebugs[i] = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
+		}
+	}
 
-			scores := search.DebugSimilarityWithTFIDF(&buf, query, index, tfidfIndex)
-			score = scores.FinalScore
+	score := func(w int, entities []search.Entity[search.Value]) {
+		var debugLocal *largest.Items[debugRespone]
+		if opts.Debug {
+			debugLocal = localDebugs[w]
+		}
+		scoreEntities(entities, query, tfidfIndex, opts, hasDebugIDs, s.logger, localItems[w], debugLocal)
+	}
 
-			if debugSourceID {
-				s.logger.Debug().With(log.Fields{
-					"debug_source_id": log.String(index.SourceID),
-				}).Logf("similarity score: %#v", scores)
-
-				s.logger.Debug().With(log.Fields{
-					"debug_source_id": log.String(index.SourceID),
-				}).Logf("scoring debug: %#v", buf.String())
+	if goroutineCount <= 1 || len(searchEntities) < goroutineCount {
+		score(0, searchEntities)
+	} else {
+		chunkSize := (len(searchEntities) + goroutineCount - 1) / goroutineCount
+		var wg sync.WaitGroup
+		worker := 0
+		for startIdx := 0; startIdx < len(searchEntities); startIdx += chunkSize {
+			endIdx := startIdx + chunkSize
+			if endIdx > len(searchEntities) {
+				endIdx = len(searchEntities)
 			}
-
-			// Add debug buffer to be stored
-			debugs.Add(largest.Item[debugRespone]{
-				Value: debugRespone{
-					scores: scores,
-					buffer: &buf,
-				},
-				Weight: score,
-			})
+			w := worker
+			if w >= goroutineCount {
+				w = goroutineCount - 1
+			}
+			wg.Add(1)
+			go func(w, startIdx, endIdx int) {
+				defer wg.Done()
+				score(w, searchEntities[startIdx:endIdx])
+			}(w, startIdx, endIdx)
+			worker++
 		}
+		wg.Wait()
+	}
 
-		dur := time.Since(start)
-		stats.AddDuration(dur)
-
-		if debugSourceID {
-			s.logger.Debug().With(log.Fields{
-				"debug_source_id": log.String(index.SourceID),
-			}).Logf("final score: %.5f after %v", score, dur)
+	// Merge local top-K into final results
+	items := largest.NewItems[search.Entity[search.Value]](opts.Limit, opts.MinMatch)
+	var debugs *largest.Items[debugRespone]
+	if opts.Debug {
+		debugs = largest.NewItems[debugRespone](opts.Limit, opts.MinMatch)
+	}
+	for i := range localItems {
+		items.Merge(localItems[i])
+		if opts.Debug {
+			debugs.Merge(localDebugs[i])
 		}
-
-		items.Add(largest.Item[search.Entity[search.Value]]{
-			Value:  index,
-			Weight: score,
-		})
-	})
+	}
 
 	diff := time.Since(start)
 	s.cm.RecordDuration(goroutineCount, diff)
@@ -306,11 +336,11 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 		attribute.Int64("search.duration", diff.Milliseconds()),
 	)
 
-	// After processing the list add stats to the span
-	stats.AddEvent(span)
-
 	results := items.Items()
-	debugLogs := debugs.Items()
+	var debugLogs []largest.Item[debugRespone]
+	if debugs != nil {
+		debugLogs = debugs.Items()
+	}
 	var out []search.SearchedEntity[search.Value]
 
 	for idx, res := range results {
@@ -336,6 +366,69 @@ func (s *service) performSearch(ctx context.Context, query search.Entity[search.
 	}
 
 	return out, nil
+}
+
+func scoreEntities(
+	entities []search.Entity[search.Value],
+	query search.Entity[search.Value],
+	tfidfIndex *tfidf.Index,
+	opts SearchOpts,
+	hasDebugIDs bool,
+	logger log.Logger,
+	items *largest.Items[search.Entity[search.Value]],
+	debugs *largest.Items[debugRespone],
+) {
+	for i := range entities {
+		indexEntity := entities[i]
+
+		if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+			logger.Debug().With(log.Fields{
+				"debug_source_id": log.String(indexEntity.SourceID),
+			}).Logf("indexed entity: %#v", indexEntity)
+		}
+
+		var score float64
+		if !opts.Debug {
+			score = search.SimilarityWithTFIDF(query, indexEntity, tfidfIndex)
+		} else {
+			var buf bytes.Buffer
+			buf.Grow(1700) // approximate size of debug logs
+
+			scores := search.DebugSimilarityWithTFIDF(&buf, query, indexEntity, tfidfIndex)
+			score = scores.FinalScore
+
+			if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+				logger.Debug().With(log.Fields{
+					"debug_source_id": log.String(indexEntity.SourceID),
+				}).Logf("similarity score: %#v", scores)
+
+				logger.Debug().With(log.Fields{
+					"debug_source_id": log.String(indexEntity.SourceID),
+				}).Logf("scoring debug: %#v", buf.String())
+			}
+
+			if debugs != nil {
+				debugs.AddLocal(largest.Item[debugRespone]{
+					Value: debugRespone{
+						scores: scores,
+						buffer: &buf,
+					},
+					Weight: score,
+				})
+			}
+		}
+
+		if hasDebugIDs && slices.Contains(opts.DebugSourceIDs, indexEntity.SourceID) {
+			logger.Debug().With(log.Fields{
+				"debug_source_id": log.String(indexEntity.SourceID),
+			}).Logf("final score: %.5f", score)
+		}
+
+		items.AddLocal(largest.Item[search.Entity[search.Value]]{
+			Value:  indexEntity,
+			Weight: score,
+		})
+	}
 }
 
 func getGoroutineCount(cm *concurrencychamp.ConcurrencyManager) (int, error) {

--- a/internal/stringscore/jaro_winkler.go
+++ b/internal/stringscore/jaro_winkler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/moov-io/base/strx"
 
@@ -25,7 +26,32 @@ var (
 	// Watchman parameters
 	exactMatchFavoritism        = readFloat(os.Getenv("EXACT_MATCH_FAVORITISM"), 0.0)
 	unmatchedIndexPenaltyWeight = readFloat(os.Getenv("UNMATCHED_INDEX_TOKEN_WEIGHT"), 0.15)
+
+	// Hot-path feature flags (read once; call ReloadEnvConfig after changing env in tests)
+	disablePhoneticFiltering atomic.Bool
+	useSoundexMatching       atomic.Bool
+	soundexBoostWeight       atomic.Uint64 // float64 bits
 )
+
+func init() {
+	ReloadEnvConfig()
+}
+
+// ReloadEnvConfig re-reads environment-controlled scoring flags.
+// Production loads these once at startup; tests may call this after t.Setenv.
+func ReloadEnvConfig() {
+	disablePhoneticFiltering.Store(strx.Yes(os.Getenv("DISABLE_PHONETIC_FILTERING")))
+	useSoundexMatching.Store(strx.Yes(os.Getenv("USE_SOUNDEX_MATCHING")))
+	soundexBoostWeight.Store(math.Float64bits(readFloat(os.Getenv("SOUNDEX_BOOST_WEIGHT"), 0.0)))
+}
+
+// ResetEnvConfigForTest clears hot-path feature flags to their default (off) state.
+// Intended for test cleanup so parallel/sequential tests do not leak flag values.
+func ResetEnvConfigForTest() {
+	disablePhoneticFiltering.Store(false)
+	useSoundexMatching.Store(false)
+	soundexBoostWeight.Store(math.Float64bits(0))
+}
 
 func readFloat(override string, value float64) float64 {
 	if override != "" {
@@ -68,18 +94,18 @@ func BestPairsJaroWinkler(searchTokens []string, indexedTokens []string) float64
 	searchTokensLength := sumLength(searchTokens)
 	indexTokensLength := sumLength(indexedTokens)
 
-	disablePhoneticFiltering := strx.Yes(os.Getenv("DISABLE_PHONETIC_FILTERING"))
+	skipPhonetic := disablePhoneticFiltering.Load()
 
 	//Compare each search token to each indexed token. Sort the results in descending order
 	scoresCapacity := (len(searchTokens) + len(indexedTokens))
-	if !disablePhoneticFiltering {
+	if !skipPhonetic {
 		scoresCapacity /= 5 // reduce the capacity as many terms don't phonetically match
 	}
 	scores := make([]Score, 0, scoresCapacity)
 	for searchIdx, searchToken := range searchTokens {
 		for indexIdx, indexedToken := range indexedTokens {
 			// Compare the first letters phonetically and only run jaro-winkler on those which are similar
-			if disablePhoneticFiltering || firstCharacterSoundexMatch(indexedToken, searchToken) {
+			if skipPhonetic || firstCharacterSoundexMatch(indexedToken, searchToken) {
 				scores = append(scores, Score{
 					score:          customJaroWinkler(indexedToken, searchToken),
 					searchTokenIdx: searchIdx,
@@ -151,8 +177,8 @@ func customJaroWinkler(s1 string, s2 string) float64 {
 
 	// Optional Soundex phonetic boost for pairs that encode to the same full Soundex code.
 	// Enabled via USE_SOUNDEX_MATCHING=yes and controlled by SOUNDEX_BOOST_WEIGHT (e.g. 0.12).
-	if strx.Yes(os.Getenv("USE_SOUNDEX_MATCHING")) {
-		boostWeight := readFloat(os.Getenv("SOUNDEX_BOOST_WEIGHT"), 0.0)
+	if useSoundexMatching.Load() {
+		boostWeight := math.Float64frombits(soundexBoostWeight.Load())
 		if boostWeight > 0 && SoundexMatch(s1, s2) {
 			score *= (1.0 + boostWeight)
 			if score > 1.0 {
@@ -405,17 +431,17 @@ func BestPairsJaroWinklerWeighted(searchTokens []string, indexedTokens []string,
 		indexTokenIdx  int
 	}
 
-	disablePhoneticFiltering := strx.Yes(os.Getenv("DISABLE_PHONETIC_FILTERING"))
+	skipPhonetic := disablePhoneticFiltering.Load()
 
 	// Compare each search token to each indexed token
 	scoresCapacity := (len(searchTokens) + len(indexedTokens))
-	if !disablePhoneticFiltering {
+	if !skipPhonetic {
 		scoresCapacity /= 5
 	}
 	scores := make([]Score, 0, scoresCapacity)
 	for searchIdx, searchToken := range searchTokens {
 		for indexIdx, indexedToken := range indexedTokens {
-			if disablePhoneticFiltering || firstCharacterSoundexMatch(indexedToken, searchToken) {
+			if skipPhonetic || firstCharacterSoundexMatch(indexedToken, searchToken) {
 				scores = append(scores, Score{
 					score:          customJaroWinkler(indexedToken, searchToken),
 					searchTokenIdx: searchIdx,

--- a/internal/stringscore/jaro_winkler_test.go
+++ b/internal/stringscore/jaro_winkler_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestJaroWinkler(t *testing.T) {
+	t.Cleanup(stringscore.ResetEnvConfigForTest)
 	t.Setenv("DISABLE_PHONETIC_FILTERING", "")
+	stringscore.ReloadEnvConfig()
 
 	cases := []struct {
 		indexed, search string
@@ -230,8 +232,11 @@ func TestEql(t *testing.T) {
 
 // TestJaroWinklerWithSoundex verifies Soundex boost integration.
 func TestJaroWinklerWithSoundex(t *testing.T) {
+	t.Cleanup(stringscore.ResetEnvConfigForTest)
+
 	t.Run("Soundex disabled", func(t *testing.T) {
 		t.Setenv("USE_SOUNDEX_MATCHING", "no")
+		stringscore.ReloadEnvConfig()
 
 		// Should work as before (no Soundex boost)
 		score := stringscore.BestPairsJaroWinkler(
@@ -244,6 +249,7 @@ func TestJaroWinklerWithSoundex(t *testing.T) {
 	t.Run("Soundex enabled - matching phonetics", func(t *testing.T) {
 		t.Setenv("USE_SOUNDEX_MATCHING", "yes")
 		t.Setenv("SOUNDEX_BOOST_WEIGHT", "0.12")
+		stringscore.ReloadEnvConfig()
 
 		// These should get a Soundex boost (base scores ~0.81 and ~0.92 get lifted)
 		scoringCases := []struct {
@@ -267,6 +273,7 @@ func TestJaroWinklerWithSoundex(t *testing.T) {
 
 	t.Run("Soundex enabled - non-matching phonetics", func(t *testing.T) {
 		t.Setenv("USE_SOUNDEX_MATCHING", "yes")
+		stringscore.ReloadEnvConfig()
 
 		// These should NOT get a Soundex boost
 		score := stringscore.BestPairsJaroWinkler(
@@ -279,11 +286,13 @@ func TestJaroWinklerWithSoundex(t *testing.T) {
 	t.Run("Feature flag test", func(t *testing.T) {
 		// With flag disabled, legacy behavior (no boost)
 		t.Setenv("USE_SOUNDEX_MATCHING", "no")
+		stringscore.ReloadEnvConfig()
 		score1 := stringscore.BestPairsJaroWinkler(strings.Fields("smith"), strings.Fields("smythe"))
 
 		// With flag enabled + positive weight, score should be strictly higher
 		t.Setenv("USE_SOUNDEX_MATCHING", "yes")
 		t.Setenv("SOUNDEX_BOOST_WEIGHT", "0.10")
+		stringscore.ReloadEnvConfig()
 		score2 := stringscore.BestPairsJaroWinkler(strings.Fields("smith"), strings.Fields("smythe"))
 
 		require.Greater(t, score2, score1, "Soundex-boosted score should be strictly greater than non-boosted")

--- a/internal/stringscore/new_algorithm_test.go
+++ b/internal/stringscore/new_algorithm_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestBestPairsJaroWinkler__FalsePositives(t *testing.T) {
+	t.Cleanup(stringscore.ResetEnvConfigForTest)
+	stringscore.ResetEnvConfigForTest()
+
 	// Words in the query should be matched against at most one indexed word. Doubled names on the sanctioned list can
 	// skew results
 	// 1. SDN Entity 40273, VLADIMIROV, Vladimir Vladimirovich
@@ -48,6 +51,9 @@ func TestBestPairsJaroWinkler__FalsePositives(t *testing.T) {
 }
 
 func TestBestPairsJaroWinkler__TruePositives(t *testing.T) {
+	t.Cleanup(stringscore.ResetEnvConfigForTest)
+	stringscore.ResetEnvConfigForTest()
+
 	// Unmatched indexed words had a large weight, causing false negatives for missing "middle names"
 	// 1. Saddam Hussein
 	oldScore, newScore := compareAlgorithms("saddam hussein al tikriti", "saddam hussien")

--- a/internal/stringscore/phonetics_test.go
+++ b/internal/stringscore/phonetics_test.go
@@ -20,15 +20,19 @@ func TestFirstCharacterSoundexMatch(t *testing.T) {
 }
 
 func TestDisablePhoneticFiltering(t *testing.T) {
+	t.Cleanup(ResetEnvConfigForTest)
+
 	search := strings.Fields("ian mckinley")
 	indexed := strings.Fields("tian xiang 7")
 
 	t.Setenv("DISABLE_PHONETIC_FILTERING", "no")
+	ReloadEnvConfig()
 	score := BestPairsJaroWinkler(search, indexed)
 	require.InDelta(t, 0.00, score, 0.01)
 
 	// Disable filtering (force the compare)
 	t.Setenv("DISABLE_PHONETIC_FILTERING", "yes")
+	ReloadEnvConfig()
 
 	score = BestPairsJaroWinkler(search, indexed)
 	require.InDelta(t, 0.544, score, 0.01)

--- a/pkg/search/models.go
+++ b/pkg/search/models.go
@@ -269,6 +269,18 @@ type PreparedFields struct {
 	NameFields    []string
 	AltNameFields [][]string
 
+	// HistoricalNames / HistoricalNameFields are precomputed "Former Name" values
+	// so search does not re-normalize them on every comparison.
+	HistoricalNames      []string
+	HistoricalNameFields [][]string
+
+	// Optional TF-IDF term weights aligned with NameFields / AltNameFields /
+	// HistoricalNameFields. Populated at index build time when TF-IDF is enabled;
+	// for query entities, NameWeights is set once per search.
+	NameWeights           []float64
+	AltNameWeights        [][]float64
+	HistoricalNameWeights [][]float64
+
 	Contact   ContactInfo
 	Addresses []PreparedAddress
 }
@@ -316,6 +328,22 @@ func (e Entity[T]) Normalize() Entity[T] {
 		for idx := range e.PreparedFields.AltNames {
 			e.PreparedFields.AltNameFields[idx] = removeStopwords(e.PreparedFields.AltNames[idx])
 		}
+	}
+
+	// Historical former names (precompute for search hot path)
+	if len(e.HistoricalInfo) > 0 {
+		var names []string
+		var fields [][]string
+		for _, hist := range e.HistoricalInfo {
+			if !strings.EqualFold(hist.Type, "Former Name") || hist.Value == "" {
+				continue
+			}
+			prepared := prepare.LowerAndRemovePunctuation(hist.Value)
+			names = append(names, prepared)
+			fields = append(fields, removeStopwords(prepared))
+		}
+		e.PreparedFields.HistoricalNames = names
+		e.PreparedFields.HistoricalNameFields = fields
 	}
 
 	// Contact

--- a/pkg/search/similarity.go
+++ b/pkg/search/similarity.go
@@ -49,8 +49,9 @@ func Similarity[Q any, I any](query Entity[Q], index Entity[I]) float64 {
 
 // SimilarityWithTFIDF calculates a match score with optional TF-IDF weighting for name matching.
 // When tfidfIndex is nil or disabled, falls back to standard scoring.
+// This path avoids allocating the detailed ScorePiece slice returned by DebugSimilarity.
 func SimilarityWithTFIDF[Q any, I any](query Entity[Q], index Entity[I], tfidfIndex *tfidf.Index) float64 {
-	return DebugSimilarityWithTFIDF(nil, query, index, tfidfIndex).FinalScore
+	return scoreSimilarityFast(query, index, tfidfIndex)
 }
 
 // DebugSimilarity does the same as Similarity, but logs debug info to w.
@@ -137,13 +138,12 @@ func DetailedSimilarity[Q any, I any](w io.Writer, query Entity[Q], index Entity
 
 // DetailedSimilarityWithTFIDF returns scoring details with optional TF-IDF weighting for name matching.
 func DetailedSimilarityWithTFIDF[Q any, I any](w io.Writer, query Entity[Q], index Entity[I], tfidfIndex *tfidf.Index) SimilarityScore {
-	out := SimilarityScore{
-		Pieces: make([]ScorePiece, 0, 9),
-	}
+	var out SimilarityScore
 
 	var exactOverride bool
 
-	// Quick filters
+	// Quick filters — these are free when the search service already partitioned,
+	// but remain here for direct Similarity() callers.
 	if query.Source != sourceEmpty && !query.Source.IsRequestType() {
 		if query.Source != index.Source {
 			out.Pieces = emptyPieces
@@ -166,56 +166,120 @@ func DetailedSimilarityWithTFIDF[Q any, I any](w io.Writer, query Entity[Q], ind
 		}
 	}
 
+	// Stack-allocated piece buffer avoids per-comparison heap alloc of the slice header backing array
+	var pieces [9]ScorePiece
+
 	// Critical identifiers (highest weight)
-	exactIdentifiers := compareExactIdentifiers(w, query, index, criticalIdWeight)
-	if exactIdentifiers.Matched && exactIdentifiers.FieldsCompared > 0 {
+	pieces[0] = compareExactIdentifiers(w, query, index, criticalIdWeight)
+	if pieces[0].Matched && pieces[0].FieldsCompared > 0 {
 		exactOverride = true
-		if math.IsNaN(exactIdentifiers.Score) {
-			exactIdentifiers.Score = 1.0
+		if math.IsNaN(pieces[0].Score) {
+			pieces[0].Score = 1.0
 		}
 	}
 
-	exactCryptoAddresses := compareExactCryptoAddresses(w, query, index, criticalIdWeight)
-	if exactCryptoAddresses.Matched && exactCryptoAddresses.FieldsCompared > 0 {
+	pieces[1] = compareExactCryptoAddresses(w, query, index, criticalIdWeight)
+	if pieces[1].Matched && pieces[1].FieldsCompared > 0 {
 		exactOverride = true
-		if math.IsNaN(exactCryptoAddresses.Score) {
-			exactCryptoAddresses.Score = 1.0
+		if math.IsNaN(pieces[1].Score) {
+			pieces[1].Score = 1.0
 		}
 	}
 
-	exactGovernmentIDs := compareExactGovernmentIDs(w, query, index, criticalIdWeight)
-	if exactGovernmentIDs.Matched && exactGovernmentIDs.FieldsCompared > 0 {
+	pieces[2] = compareExactGovernmentIDs(w, query, index, criticalIdWeight)
+	if pieces[2].Matched && pieces[2].FieldsCompared > 0 {
 		exactOverride = true
-		if math.IsNaN(exactGovernmentIDs.Score) {
-			exactGovernmentIDs.Score = 1.0
+		if math.IsNaN(pieces[2].Score) {
+			pieces[2].Score = 1.0
 		}
 	}
 
-	exactContactInfo := compareExactContactInfo(w, query, index, criticalIdWeight)
-	if exactContactInfo.Matched && exactContactInfo.FieldsCompared > 0 {
+	pieces[3] = compareExactContactInfo(w, query, index, criticalIdWeight)
+	if pieces[3].Matched && pieces[3].FieldsCompared > 0 {
 		exactOverride = true
-		if math.IsNaN(exactContactInfo.Score) {
-			exactContactInfo.Score = 1.0
+		if math.IsNaN(pieces[3].Score) {
+			pieces[3].Score = 1.0
 		}
 	}
-	out.Pieces = append(out.Pieces, exactIdentifiers, exactCryptoAddresses, exactGovernmentIDs, exactContactInfo)
 
 	// Name comparison (second highest weight) - use TF-IDF if provided
-	out.Pieces = append(out.Pieces,
-		compareNameWithTFIDF(w, query, index, nameWeight, tfidfIndex),
-		compareEntityTitlesFuzzy(w, query, index, nameWeight),
-	)
+	pieces[4] = compareNameWithTFIDF(w, query, index, nameWeight, tfidfIndex)
+	pieces[5] = compareEntityTitlesFuzzy(w, query, index, nameWeight)
 
 	// Supporting information (lower weight)
-	out.Pieces = append(out.Pieces,
-		compareEntityDates(w, query, index, supportingInfoWeight),
-		compareAddresses(w, query, index, addressWeight),
-		compareSupportingInfo(w, query, index, supportingInfoWeight),
-	)
+	pieces[6] = compareEntityDates(w, query, index, supportingInfoWeight)
+	pieces[7] = compareAddresses(w, query, index, addressWeight)
+	pieces[8] = compareSupportingInfo(w, query, index, supportingInfoWeight)
 
-	out.FinalScore = calculateFinalScore(w, out.Pieces, exactOverride, query, index)
+	pieceSlice := pieces[:]
+	out.FinalScore = calculateFinalScore(w, pieceSlice, exactOverride, query, index)
+
+	// Only allocate a heap-backed Pieces slice when the caller needs details (debug writer)
+	// or when Exact override short pieces aren't used. Always copy for API stability of Details.
+	out.Pieces = make([]ScorePiece, 9)
+	copy(out.Pieces, pieceSlice)
 
 	return out
+}
+
+// scoreSimilarityFast is the allocation-light path used by bulk search: it returns only the final score.
+func scoreSimilarityFast[Q any, I any](query Entity[Q], index Entity[I], tfidfIndex *tfidf.Index) float64 {
+	// Quick filters
+	if query.Source != sourceEmpty && !query.Source.IsRequestType() {
+		if query.Source != index.Source {
+			return 0
+		}
+	}
+	if query.SourceID != "" {
+		if query.SourceID == index.SourceID {
+			return 1.0
+		}
+		return 0
+	}
+	if query.Type != emptyEntityType {
+		if query.Type != index.Type {
+			return 0
+		}
+	}
+
+	var exactOverride bool
+	var pieces [9]ScorePiece
+
+	pieces[0] = compareExactIdentifiers(nil, query, index, criticalIdWeight)
+	if pieces[0].Matched && pieces[0].FieldsCompared > 0 {
+		exactOverride = true
+		if math.IsNaN(pieces[0].Score) {
+			pieces[0].Score = 1.0
+		}
+	}
+	pieces[1] = compareExactCryptoAddresses(nil, query, index, criticalIdWeight)
+	if pieces[1].Matched && pieces[1].FieldsCompared > 0 {
+		exactOverride = true
+		if math.IsNaN(pieces[1].Score) {
+			pieces[1].Score = 1.0
+		}
+	}
+	pieces[2] = compareExactGovernmentIDs(nil, query, index, criticalIdWeight)
+	if pieces[2].Matched && pieces[2].FieldsCompared > 0 {
+		exactOverride = true
+		if math.IsNaN(pieces[2].Score) {
+			pieces[2].Score = 1.0
+		}
+	}
+	pieces[3] = compareExactContactInfo(nil, query, index, criticalIdWeight)
+	if pieces[3].Matched && pieces[3].FieldsCompared > 0 {
+		exactOverride = true
+		if math.IsNaN(pieces[3].Score) {
+			pieces[3].Score = 1.0
+		}
+	}
+	pieces[4] = compareNameWithTFIDF(nil, query, index, nameWeight, tfidfIndex)
+	pieces[5] = compareEntityTitlesFuzzy(nil, query, index, nameWeight)
+	pieces[6] = compareEntityDates(nil, query, index, supportingInfoWeight)
+	pieces[7] = compareAddresses(nil, query, index, addressWeight)
+	pieces[8] = compareSupportingInfo(nil, query, index, supportingInfoWeight)
+
+	return calculateFinalScore(nil, pieces[:], exactOverride, query, index)
 }
 
 // SimilarityScore gives detailed results of which fields matched and how they were scored against each other.

--- a/pkg/search/similarity.go
+++ b/pkg/search/similarity.go
@@ -242,44 +242,37 @@ func scoreSimilarityFast[Q any, I any](query Entity[Q], index Entity[I], tfidfIn
 		}
 	}
 
-	var exactOverride bool
-	var pieces [9]ScorePiece
+	// Critical exact matches always force final score 1.0 — skip expensive name/address work.
+	p0 := compareExactIdentifiers(nil, query, index, criticalIdWeight)
+	if p0.Matched && p0.FieldsCompared > 0 {
+		return 1.0
+	}
+	p1 := compareExactCryptoAddresses(nil, query, index, criticalIdWeight)
+	if p1.Matched && p1.FieldsCompared > 0 {
+		return 1.0
+	}
+	p2 := compareExactGovernmentIDs(nil, query, index, criticalIdWeight)
+	if p2.Matched && p2.FieldsCompared > 0 {
+		return 1.0
+	}
+	p3 := compareExactContactInfo(nil, query, index, criticalIdWeight)
+	if p3.Matched && p3.FieldsCompared > 0 {
+		return 1.0
+	}
 
-	pieces[0] = compareExactIdentifiers(nil, query, index, criticalIdWeight)
-	if pieces[0].Matched && pieces[0].FieldsCompared > 0 {
-		exactOverride = true
-		if math.IsNaN(pieces[0].Score) {
-			pieces[0].Score = 1.0
-		}
+	pieces := [9]ScorePiece{
+		p0,
+		p1,
+		p2,
+		p3,
+		compareNameWithTFIDF(nil, query, index, nameWeight, tfidfIndex),
+		compareEntityTitlesFuzzy(nil, query, index, nameWeight),
+		compareEntityDates(nil, query, index, supportingInfoWeight),
+		compareAddresses(nil, query, index, addressWeight),
+		compareSupportingInfo(nil, query, index, supportingInfoWeight),
 	}
-	pieces[1] = compareExactCryptoAddresses(nil, query, index, criticalIdWeight)
-	if pieces[1].Matched && pieces[1].FieldsCompared > 0 {
-		exactOverride = true
-		if math.IsNaN(pieces[1].Score) {
-			pieces[1].Score = 1.0
-		}
-	}
-	pieces[2] = compareExactGovernmentIDs(nil, query, index, criticalIdWeight)
-	if pieces[2].Matched && pieces[2].FieldsCompared > 0 {
-		exactOverride = true
-		if math.IsNaN(pieces[2].Score) {
-			pieces[2].Score = 1.0
-		}
-	}
-	pieces[3] = compareExactContactInfo(nil, query, index, criticalIdWeight)
-	if pieces[3].Matched && pieces[3].FieldsCompared > 0 {
-		exactOverride = true
-		if math.IsNaN(pieces[3].Score) {
-			pieces[3].Score = 1.0
-		}
-	}
-	pieces[4] = compareNameWithTFIDF(nil, query, index, nameWeight, tfidfIndex)
-	pieces[5] = compareEntityTitlesFuzzy(nil, query, index, nameWeight)
-	pieces[6] = compareEntityDates(nil, query, index, supportingInfoWeight)
-	pieces[7] = compareAddresses(nil, query, index, addressWeight)
-	pieces[8] = compareSupportingInfo(nil, query, index, supportingInfoWeight)
 
-	return calculateFinalScore(nil, pieces[:], exactOverride, query, index)
+	return calculateFinalScore(nil, pieces[:], false, query, index)
 }
 
 // SimilarityScore gives detailed results of which fields matched and how they were scored against each other.

--- a/pkg/search/similarity_fuzzy.go
+++ b/pkg/search/similarity_fuzzy.go
@@ -52,33 +52,40 @@ func compareNameWithTFIDF[Q any, I any](w io.Writer, query Entity[Q], index Enti
 		}
 	}
 
+	queryTerms := query.PreparedFields.NameFields
+	queryWeights := query.PreparedFields.NameWeights
+
 	// Check primary name
-	bestMatch := compareNameTermsWithTFIDF(query.PreparedFields.NameFields, index.PreparedFields.NameFields, tfidfIndex)
+	bestMatch := compareNameTermsWeighted(queryTerms, index.PreparedFields.NameFields, queryWeights, index.PreparedFields.NameWeights, tfidfIndex)
 
 	// Check alternate names
 	for idx := range index.PreparedFields.AltNameFields {
-		altMatch := compareNameTermsWithTFIDF(query.PreparedFields.NameFields, index.PreparedFields.AltNameFields[idx], tfidfIndex)
+		var indexWeights []float64
+		if idx < len(index.PreparedFields.AltNameWeights) {
+			indexWeights = index.PreparedFields.AltNameWeights[idx]
+		}
+		altMatch := compareNameTermsWeighted(queryTerms, index.PreparedFields.AltNameFields[idx], queryWeights, indexWeights, tfidfIndex)
 		if altMatch.score > bestMatch.score {
 			bestMatch = altMatch
 		}
 	}
 
-	// Check historical names with penalty
-	for _, hist := range index.HistoricalInfo {
-		if strings.EqualFold(hist.Type, "Former Name") {
-			indexHistoricalTerms := strings.Fields(prepare.LowerAndRemovePunctuation(hist.Value))
-
-			histMatch := compareNameTermsWithTFIDF(query.PreparedFields.NameFields, indexHistoricalTerms, tfidfIndex)
-			histMatch.score *= 0.95 // Apply penalty for historical names
-			histMatch.isHistorical = true
-			if histMatch.score > bestMatch.score {
-				bestMatch = histMatch
-			}
+	// Check historical names with penalty (precomputed at Normalize time)
+	for idx := range index.PreparedFields.HistoricalNameFields {
+		var indexWeights []float64
+		if idx < len(index.PreparedFields.HistoricalNameWeights) {
+			indexWeights = index.PreparedFields.HistoricalNameWeights[idx]
+		}
+		histMatch := compareNameTermsWeighted(queryTerms, index.PreparedFields.HistoricalNameFields[idx], queryWeights, indexWeights, tfidfIndex)
+		histMatch.score *= 0.95 // Apply penalty for historical names
+		histMatch.isHistorical = true
+		if histMatch.score > bestMatch.score {
+			bestMatch = histMatch
 		}
 	}
 
 	// Apply additional criteria for match quality
-	bestMatch.score = adjustScoreBasedOnQuality(bestMatch, len(query.PreparedFields.NameFields))
+	bestMatch.score = adjustScoreBasedOnQuality(bestMatch, len(queryTerms))
 	if !isNameCloseEnough(query.PreparedFields, index.PreparedFields) {
 		bestMatch.score *= 0.85
 	}
@@ -96,18 +103,30 @@ func compareNameWithTFIDF[Q any, I any](w io.Writer, query Entity[Q], index Enti
 
 // compareNameFields performs detailed term-by-term comparison
 func compareNameTerms(queryTerms, indexTerms []string) nameMatch {
-	return compareNameTermsWithTFIDF(queryTerms, indexTerms, nil)
+	return compareNameTermsWeighted(queryTerms, indexTerms, nil, nil, nil)
 }
 
 // compareNameTermsWithTFIDF performs term-by-term comparison with optional TF-IDF weighting.
 // When tfidfIndex is nil or disabled, falls back to unweighted comparison.
 func compareNameTermsWithTFIDF(queryTerms, indexTerms []string, tfidfIndex *tfidf.Index) nameMatch {
+	return compareNameTermsWeighted(queryTerms, indexTerms, nil, nil, tfidfIndex)
+}
+
+// compareNameTermsWeighted prefers precomputed weights; falls back to tfidfIndex.GetWeights
+// only when weights are missing and the index is enabled.
+func compareNameTermsWeighted(queryTerms, indexTerms []string, queryWeights, indexWeights []float64, tfidfIndex *tfidf.Index) nameMatch {
 	var score float64
 	if len(indexTerms) > 0 {
-		// Use TF-IDF weighted scoring if enabled
-		if tfidfIndex != nil && tfidfIndex.Enabled() {
-			queryWeights := tfidfIndex.GetWeights(queryTerms)
-			indexWeights := tfidfIndex.GetWeights(indexTerms)
+		useWeighted := false
+		if len(queryWeights) == len(queryTerms) && len(indexWeights) == len(indexTerms) {
+			useWeighted = true
+		} else if tfidfIndex != nil && tfidfIndex.Enabled() {
+			queryWeights = tfidfIndex.GetWeights(queryTerms)
+			indexWeights = tfidfIndex.GetWeights(indexTerms)
+			useWeighted = len(queryWeights) == len(queryTerms) && len(indexWeights) == len(indexTerms)
+		}
+
+		if useWeighted {
 			score = stringscore.BestPairCombinationJaroWinklerWeighted(queryTerms, indexTerms, queryWeights, indexWeights)
 		} else {
 			score = stringscore.BestPairCombinationJaroWinkler(queryTerms, indexTerms)


### PR DESCRIPTION
## Summary

Speeds up the search path for high-volume screening (~100 req/s per instance) without reducing recall below a full source/type partition scan.

1. **Corpus partitions + inverted candidate indexes** — on list `Update`, build source×type partitions, name-token postings (primary/alt/historical), crypto exact lookup, and index-time TF-IDF weights. `SelectCandidates` scores a subset; empty token hits (e.g. pure typos) fall back to the full partition.
2. **Search service** — use candidates instead of the full entity list, bound concurrent searches with `SEARCH_MAX_IN_FLIGHT` (default `GOMAXPROCS`), shard top-K per worker (`AddLocal`/`Merge`), and drop per-entity timing locks.
3. **Similarity / JW hot path** — stack-based fast score path, precomputed historical name fields, prefer precomputed TF-IDF weights, hoist `os.Getenv` scoring flags into atomics.

## Benchstat (master vs this branch)

Apple M4 Max, darwin/arm64, `-count=10 -benchtime=500ms -benchmem`:

| Benchmark | master | this PR | Δ |
|-----------|--------|---------|---|
| `API_Search/normal` | 7.07 ms | 0.29 ms | **−96.0%** |
| `API_Search/debug` | 15.3 ms | 0.54 ms | **−96.5%** |
| `Search/dynamic` (typo fallback) | 9.86 ms | 2.61 ms | **−73.5%** |
| `API_Search` allocs | ~181k | ~8.3k | **−95.4%** |
| Similarity geomean | 9.78 µs | 8.44 µs | **−13.8%** |
| `BestPairsJaroWinkler` | 1.98 µs | 1.56 µs | **−21.2%** |

API path gains are dominated by candidate pruning on tokenized name queries. Typo queries still win from less locking/allocs on a partition scan.

## Config

- `SEARCH_MAX_IN_FLIGHT` — max concurrent full searches (default `GOMAXPROCS`)
- Existing `SEARCH_GOROUTINE_COUNT` unchanged
- Prefer `type=` and `source=` on queries for best pruning

