### PR TITLE
fix: keep serving data when scheduled refresh fails

### DIFF
--- a/cmd/server/download.go
+++ b/cmd/server/download.go
@@ -17,7 +17,7 @@ import (
 )
 
 func setupPeriodicRefreshing(ctx context.Context, logger log.Logger, errs chan error, conf download.Config, r *download.Refresher) error {
-	// Initial, blocking load. A failure here is fatal to startup.
+	// Initial, blocking load. A failure here is fatal to startup — we have no data yet.
 	if err := r.RefreshNow(ctx, download.TriggerStartup); err != nil {
 		return err
 	}
@@ -38,10 +38,17 @@ func setupPeriodicRefreshing(ctx context.Context, logger log.Logger, errs chan e
 
 			case <-ticker.C:
 				// A manual refresh may be in progress; skip this tick rather than fail.
+				//
+				// Download/parse failures must not take down a healthy process. After a
+				// successful startup we already have a searchable index; a flaky origin
+				// or temporary network blip should leave that data in place and retry
+				// on the next interval. Status is still recorded on the Refresher
+				// (StateFailed + LastError) for operators and GET /v2/data/refresh.
 				err := r.RefreshNow(ctx, download.TriggerScheduled)
-				if err != nil && !errors.Is(err, download.ErrAlreadyRunning) {
-					errs <- err
+				if err == nil || errors.Is(err, download.ErrAlreadyRunning) {
+					continue
 				}
+				logger.Error().LogErrorf("scheduled data refresh failed (keeping previous data): %v", err)
 			}
 		}
 	}()

--- a/cmd/server/download_test.go
+++ b/cmd/server/download_test.go
@@ -6,7 +6,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,6 +59,89 @@ func TestDownloader_setupPeriodicRefreshing(t *testing.T) {
 	errs := make(chan error, 1)
 	err = setupPeriodicRefreshing(ctx, logger, errs, conf, r)
 	require.NoError(t, err)
+
+	cancelFunc()
+	require.NoError(t, <-errs)
+}
+
+// scriptedDownloader returns successive results from RefreshAll. After the
+// script is exhausted it repeats the last entry.
+type scriptedDownloader struct {
+	mu    sync.Mutex
+	calls int
+	steps []struct {
+		stats download.Stats
+		err   error
+	}
+}
+
+func (s *scriptedDownloader) RefreshAll(ctx context.Context) (download.Stats, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	idx := s.calls - 1
+	if idx >= len(s.steps) {
+		idx = len(s.steps) - 1
+	}
+	step := s.steps[idx]
+	return step.stats, step.err
+}
+
+func (s *scriptedDownloader) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func TestDownloader_setupPeriodicRefreshing_scheduledFailureKeepsRunning(t *testing.T) {
+	// A failed scheduled refresh must not push onto errs (which would shut down
+	// the process). The server should keep the last successful data and retry later.
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
+	ok := download.Stats{
+		Lists:      map[string]int{"us_ofac": 1},
+		ListHashes: map[string]string{"us_ofac": "abc"},
+	}
+	dl := &scriptedDownloader{
+		steps: []struct {
+			stats download.Stats
+			err   error
+		}{
+			{stats: ok},                      // startup succeeds
+			{err: errors.New("origin down")}, // first scheduled tick fails
+			{stats: ok},                      // later tick recovers
+		},
+	}
+
+	conf := download.Config{
+		RefreshInterval: 20 * time.Millisecond,
+	}
+	r := download.NewRefresher(ctx, log.NewTestLogger(), dl, index.NewLists(nil), nil)
+
+	errs := make(chan error, 4)
+	err := setupPeriodicRefreshing(ctx, log.NewTestLogger(), errs, conf, r)
+	require.NoError(t, err)
+	require.Equal(t, download.StateSucceeded, r.Status().State)
+
+	// Wait until the failing scheduled refresh has run.
+	require.Eventually(t, func() bool {
+		return dl.callCount() >= 2 && r.Status().State == download.StateFailed
+	}, 2*time.Second, 5*time.Millisecond)
+
+	require.Contains(t, r.Status().LastError, "origin down")
+
+	// Wait for a successful recovery tick so we know the loop kept going.
+	require.Eventually(t, func() bool {
+		return dl.callCount() >= 3 && r.Status().State == download.StateSucceeded
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// No fatal error should have been reported while we were running.
+	select {
+	case err := <-errs:
+		t.Fatalf("expected no fatal error from scheduled refresh failure, got %v", err)
+	default:
+	}
 
 	cancelFunc()
 	require.NoError(t, <-errs)


### PR DESCRIPTION
## Summary

After a successful startup load, a failed **scheduled** data refresh was treated as a fatal process error. `setupPeriodicRefreshing` pushed the error onto the shared `errs` channel, and `main` shut down the HTTP server — leaving operators with full downtime instead of slightly stale sanctions data.

This was reported in Slack by a community user:

> Wait, I'm just finding out that a scheduled refresh in a running watchman task (that worked on startup) can kill the task if the download didn't work (the refresh). That's not ideal because we need to use the cache module to archive a non downtime system.
>
> Not letting crash the running task would be the same result as using a cache. I get that you want to separate these things: A watchman task runs and is always up to date. If we use a cache it's legally our own decision. But that makes it more complicated (technically) than it needs to be. A 1h downtime leads to no working watchman instead of a slightly out of date database.

### Behavior change

| Path | Before | After |
|------|--------|-------|
| Startup refresh fails | Fatal (no data yet) | Unchanged — still fatal |
| Scheduled refresh fails | Process exits | Log error, keep previous index, retry next interval |
| Manual `POST /v2/data/refresh` fails | Already non-fatal (`TriggerAsync`) | Unchanged |
| Index swap on failure | Already skipped (`Update` only on success) | Unchanged |

Refresh status is still recorded on the `Refresher` (`StateFailed` + `LastError`) and exposed via `GET /v2/data/refresh`.

This does not replace [watchman-cache](https://github.com/moov-io/watchman-cache) / `INITIAL_DATA_DIRECTORY` for offline startups or prolonged origin outages — it only stops a flaky periodic download from taking down a healthy process.

## Test plan

- [x] `go test ./cmd/server/ -run 'TestGetRefreshInterval|TestDownloader_setupPeriodicRefreshing' -count=1`
- [x] New test: startup succeeds → scheduled tick fails → later tick recovers; no fatal error on `errs`
- [ ] Manual: run server, force a bad download URL mid-run, confirm process stays up and search still works against previous data