### PR TITLE
experiment: corpusfile hot/cold memory sketch (not for merge)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,7 @@ func main() {
 	webuiController := webui.NewController(logger, conf.Webui)
 	webuiController.AppendRoutes(router)
 
-	// Start Admin server (with Prometheus metrics)
+	// Start Admin server (with Prometheus metrics + pprof)
 	adminServer, err := admin.New(admin.Opts{
 		Addr: conf.Servers.AdminAddress,
 	})
@@ -173,6 +173,8 @@ func main() {
 		errs <- fmt.Errorf("problem starting admin server: %v", err)
 	} else {
 		adminServer.AddVersionHandler(watchman.Version) // Setup 'GET /version'
+		// Live MemStats + corpus counts; pprof heap/allocs already on this server.
+		index.RegisterMemoryAdmin(adminServer, indexedLists)
 	}
 	go func() {
 		if adminServer == nil {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/klauspost/compress v1.18.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/moov-io/base v0.61.3
 	github.com/moov-io/gopostal v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -49,16 +49,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/OpenRouterTeam/go-sdk v0.5.30 h1:pZvKYI0b2uSONNcQxyn9S8HLgBel35NujIPQSzoN43U=
-github.com/OpenRouterTeam/go-sdk v0.5.30/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
-github.com/OpenRouterTeam/go-sdk v0.5.35 h1:zWh5LuGk/8lfBtz3W/sWQg2Saa9m1TNzblBHvNs7I9Y=
-github.com/OpenRouterTeam/go-sdk v0.5.35/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
-github.com/OpenRouterTeam/go-sdk v0.6.0 h1:9+BsOLoZ9IJYB2BIIY5xEkBq1JYZ/YshIhdlOjspdsI=
-github.com/OpenRouterTeam/go-sdk v0.6.0/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
-github.com/OpenRouterTeam/go-sdk v0.6.2 h1:96xSNHv8ZsY0C4mSquNQQ9xJwYnGitgvYszTBxE1AEk=
-github.com/OpenRouterTeam/go-sdk v0.6.2/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
-github.com/OpenRouterTeam/go-sdk v0.7.7 h1:5iMwsKRI3aRraO7RECooFPQhZH+RfN1cX++1siV6mTE=
-github.com/OpenRouterTeam/go-sdk v0.7.7/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
 github.com/OpenRouterTeam/go-sdk v0.7.10 h1:LCperOku8wOZCDQYoS1Ym0HOem2cnSMKpI1LQ5QoS3M=
 github.com/OpenRouterTeam/go-sdk v0.7.10/go.mod h1:8ZRHxPEBG2Lu7BXRGbcoTdhRQnXGFZ+y0jKVpCAQR8c=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -286,8 +276,6 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
 github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/moov-io/base v0.61.3 h1:c0Hvy497geIXbCA915YC6P7XxC4iKu7qdSBU2mcOGKA=

--- a/internal/corpusfile/breakdown.go
+++ b/internal/corpusfile/breakdown.go
@@ -1,0 +1,85 @@
+package corpusfile
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// FieldBreakdown estimates gob-encoded contribution of entity field groups.
+// Used to decide what to move cold next; not a precise RSS accounting.
+type FieldBreakdown struct {
+	Entities int
+	Groups   []FieldGroupSize
+	Total    int64
+}
+
+// FieldGroupSize is one logical field group.
+type FieldGroupSize struct {
+	Name  string
+	Bytes int64
+	Pct   float64
+}
+
+func (b FieldBreakdown) String() string {
+	s := fmt.Sprintf("entities=%d total=%.2fMB\n", b.Entities, float64(b.Total)/(1<<20))
+	for _, g := range b.Groups {
+		s += fmt.Sprintf("  %-22s %8.2f MB  %5.1f%%\n", g.Name, float64(g.Bytes)/(1<<20), g.Pct)
+	}
+	return s
+}
+
+// MeasureFieldBreakdown gob-encodes each field group in isolation across the corpus.
+func MeasureFieldBreakdown(entities []search.Entity[search.Value]) (FieldBreakdown, error) {
+	type bucket struct {
+		name string
+		fn   func(e search.Entity[search.Value]) any
+	}
+	buckets := []bucket{
+		{"SourceData", func(e search.Entity[search.Value]) any { return e.SourceData }},
+		{"Name+IDs", func(e search.Entity[search.Value]) any {
+			return struct {
+				Name, SourceID string
+				Type           search.EntityType
+				Source         search.SourceList
+			}{e.Name, e.SourceID, e.Type, e.Source}
+		}},
+		{"PreparedFields", func(e search.Entity[search.Value]) any { return e.PreparedFields }},
+		{"Person", func(e search.Entity[search.Value]) any { return e.Person }},
+		{"Business", func(e search.Entity[search.Value]) any { return e.Business }},
+		{"Organization", func(e search.Entity[search.Value]) any { return e.Organization }},
+		{"Aircraft", func(e search.Entity[search.Value]) any { return e.Aircraft }},
+		{"Vessel", func(e search.Entity[search.Value]) any { return e.Vessel }},
+		{"Addresses", func(e search.Entity[search.Value]) any { return e.Addresses }},
+		{"Contact", func(e search.Entity[search.Value]) any { return e.Contact }},
+		{"CryptoAddresses", func(e search.Entity[search.Value]) any { return e.CryptoAddresses }},
+		{"Affiliations", func(e search.Entity[search.Value]) any { return e.Affiliations }},
+		{"SanctionsInfo", func(e search.Entity[search.Value]) any { return e.SanctionsInfo }},
+		{"HistoricalInfo", func(e search.Entity[search.Value]) any { return e.HistoricalInfo }},
+	}
+
+	out := FieldBreakdown{Entities: len(entities)}
+	for _, b := range buckets {
+		var total int64
+		for i := range entities {
+			n, err := gobSize(b.fn(entities[i]))
+			if err != nil {
+				return out, fmt.Errorf("%s[%d]: %w", b.name, i, err)
+			}
+			total += n
+		}
+		out.Groups = append(out.Groups, FieldGroupSize{Name: b.name, Bytes: total})
+		out.Total += total
+	}
+
+	for i := range out.Groups {
+		if out.Total > 0 {
+			out.Groups[i].Pct = 100 * float64(out.Groups[i].Bytes) / float64(out.Total)
+		}
+	}
+	sort.Slice(out.Groups, func(i, j int) bool {
+		return out.Groups[i].Bytes > out.Groups[j].Bytes
+	})
+	return out, nil
+}

--- a/internal/corpusfile/collect_profiles.sh
+++ b/internal/corpusfile/collect_profiles.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Collect live Watchman memory artifacts from the admin server (default :9094).
+#
+# Usage:
+#   ./internal/corpusfile/collect_profiles.sh [admin_base_url] [out_dir]
+#
+# Example:
+#   ./internal/corpusfile/collect_profiles.sh http://127.0.0.1:9094 ./profiles
+#
+# What helps most for corpus memory work:
+#   1. heap inuse_space after refresh settles (what is retained)
+#   2. allocs alloc_space during a refresh (what refresh costs)
+#   3. /debug/memory?gc=1 JSON snapshot (entity counts + MemStats)
+#   4. optional: goroutine profile if RSS looks stuck on non-heap
+
+set -euo pipefail
+
+ADMIN="${1:-http://127.0.0.1:9094}"
+OUT="${2:-./watchman-profiles-$(date +%Y%m%d-%H%M%S)}"
+mkdir -p "$OUT"
+
+echo "Collecting from $ADMIN -> $OUT"
+
+curl -fsS "$ADMIN/debug/memory?gc=1" -o "$OUT/memory.json"
+curl -fsS "$ADMIN/debug/pprof/heap" -o "$OUT/heap.pb.gz"
+curl -fsS "$ADMIN/debug/pprof/allocs" -o "$OUT/allocs.pb.gz"
+curl -fsS "$ADMIN/debug/pprof/goroutine" -o "$OUT/goroutine.pb.gz"
+# Short CPU sample; increase seconds under load if needed.
+curl -fsS "$ADMIN/debug/pprof/profile?seconds=15" -o "$OUT/cpu.pb.gz" || true
+
+# Text top for quick glance without opening the UI
+if command -v go >/dev/null 2>&1; then
+  go tool pprof -top -inuse_space "$OUT/heap.pb.gz" >"$OUT/heap_inuse_top.txt" || true
+  go tool pprof -top -alloc_space "$OUT/allocs.pb.gz" >"$OUT/allocs_top.txt" || true
+fi
+
+cat >"$OUT/README.txt" <<EOF
+Watchman memory dump
+admin=$ADMIN
+collected=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+View interactively:
+  go tool pprof -http=:8081 $OUT/heap.pb.gz
+  # UI: Top, then sample=inuse_space (retained) vs alloc_space (cumulative)
+
+What to look for:
+  - search.Entity / PreparedFields / ofac.SDN / map[string][]int (indexes)
+  - libpostal / postal if enabled
+  - embeddings vectorData if enabled
+  - unexpected large buffers from download/parse retained after refresh
+
+Share memory.json + heap_inuse_top.txt + heap.pb.gz for corpus work.
+EOF
+
+echo "Done. Files:"
+ls -la "$OUT"

--- a/internal/corpusfile/corpus_bench_test.go
+++ b/internal/corpusfile/corpus_bench_test.go
@@ -1,0 +1,310 @@
+package corpusfile
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/moov-io/base/log"
+	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/internal/fshelp"
+	"github.com/moov-io/watchman/internal/index"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Corpus benchmarks compare today's full in-memory working set (Baseline)
+// against the tiered hot-RAM + cold-disk prototype (Tiered).
+//
+//	go test ./internal/corpusfile/ -bench='BenchmarkCorpus_' -benchmem -count=5
+//
+// Key metrics:
+//   - HeapAlive / heap bytes held by the corpus after GC
+//   - Snapshot file size (tiered only)
+//   - Similarity ns/op (score path must not regress)
+//   - Hydrate ns/op (cold read cost for top-N responses)
+//   - Candidate selection + score over a name query
+
+func BenchmarkCorpus_Baseline_Size(b *testing.B) {
+	// GC-stable size proxy for today's full in-memory []Entity (with SourceData).
+	entities := loadBenchEntities(b)
+	var report SizeReport
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := MeasureSizes(entities)
+		require.NoError(b, err)
+		report = r
+		b.ReportMetric(float64(r.Entities), "entities")
+		b.ReportMetric(float64(r.FullEntityBytes)/(1<<20), "full_MB")
+		b.ReportMetric(float64(r.FullEntityBytes)/float64(r.Entities), "full_B/entity")
+		b.ReportMetric(float64(r.HotBytes)/(1<<20), "hot_MB")
+		b.ReportMetric(float64(r.ColdBytes)/(1<<20), "cold_MB")
+	}
+	runtime.KeepAlive(report)
+}
+
+func BenchmarkCorpus_Tiered_Size(b *testing.B) {
+	// Size proxy for tiered layout: hot gob + on-disk snapshot file.
+	entities := loadBenchEntities(b)
+	dir := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := MeasureSizes(entities)
+		require.NoError(b, err)
+		path := filepath.Join(dir, fmt.Sprintf("size-%d.snap", i))
+		snap, err := BuildSnapshot(path, entities)
+		require.NoError(b, err)
+		size, err := snap.FileSize()
+		require.NoError(b, err)
+		require.NoError(b, snap.Close())
+		r.SnapshotFileBytes = size
+
+		b.ReportMetric(float64(r.Entities), "entities")
+		b.ReportMetric(float64(r.HotBytes)/(1<<20), "hot_MB")
+		b.ReportMetric(float64(r.HotBytes)/float64(r.Entities), "hot_B/entity")
+		b.ReportMetric(float64(r.SnapshotFileBytes)/(1<<20), "cold_file_MB")
+		b.ReportMetric(float64(r.SnapshotFileBytes)/float64(r.Entities), "cold_B/entity")
+		// Retained scoring set is hot only; cold lives on disk.
+		b.ReportMetric(float64(r.HotBytes)/(1<<20), "retained_MB")
+	}
+}
+
+func BenchmarkCorpus_Baseline_Similarity(b *testing.B) {
+	entities := loadBenchEntities(b)
+	queries := sampleQueries(b, entities, 64)
+	b.ReportMetric(float64(len(entities)), "entities")
+	b.ResetTimer()
+
+	var sink float64
+	for i := 0; i < b.N; i++ {
+		q := queries[i%len(queries)]
+		// Score against a rotating window to approximate candidate-set work.
+		start := (i * 17) % len(entities)
+		for j := 0; j < 256; j++ {
+			sink += search.Similarity(q, entities[(start+j)%len(entities)])
+		}
+	}
+	runtime.KeepAlive(sink)
+}
+
+func BenchmarkCorpus_Tiered_Similarity(b *testing.B) {
+	entities := loadBenchEntities(b)
+	snap, err := BuildSnapshot(filepath.Join(b.TempDir(), "corpus.snap"), entities)
+	require.NoError(b, err)
+	b.Cleanup(func() { snap.Close() })
+
+	hot := snap.HotSlice()
+	queries := sampleQueries(b, hot, 64)
+	b.ReportMetric(float64(len(hot)), "entities")
+	b.ResetTimer()
+
+	var sink float64
+	for i := 0; i < b.N; i++ {
+		q := queries[i%len(queries)]
+		start := (i * 17) % len(hot)
+		for j := 0; j < 256; j++ {
+			sink += search.Similarity(q, hot[(start+j)%len(hot)])
+		}
+	}
+	runtime.KeepAlive(sink)
+}
+
+func BenchmarkCorpus_Tiered_HydrateTopN(b *testing.B) {
+	entities := loadBenchEntities(b)
+	snap, err := BuildSnapshot(filepath.Join(b.TempDir(), "corpus.snap"), entities)
+	require.NoError(b, err)
+	b.Cleanup(func() { snap.Close() })
+
+	// Simulate hydrating top-20 hits for an API response.
+	const topN = 20
+	idxs := make([]int, topN)
+	for i := range idxs {
+		idxs[i] = (i * 97) % snap.Len()
+	}
+
+	b.ReportMetric(float64(topN), "hydrate_n")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, idx := range idxs {
+			e, err := snap.Hydrate(idx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if e.SourceData == nil {
+				b.Fatal("expected SourceData after hydrate")
+			}
+		}
+	}
+}
+
+func BenchmarkCorpus_Baseline_BuildCorpus(b *testing.B) {
+	entities := loadBenchEntities(b)
+	b.ReportMetric(float64(len(entities)), "entities")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		lists := index.NewLists(nil)
+		// download.Stats shape — Update builds partitions + inverted indexes.
+		lists.Update(benchStats(entities))
+		runtime.KeepAlive(lists)
+	}
+}
+
+func BenchmarkCorpus_Tiered_BuildCorpus(b *testing.B) {
+	entities := loadBenchEntities(b)
+	dir := b.TempDir()
+	b.ReportMetric(float64(len(entities)), "entities")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		path := filepath.Join(dir, fmt.Sprintf("build-%d.snap", i))
+		snap, err := BuildSnapshot(path, entities)
+		require.NoError(b, err)
+
+		lists := index.NewLists(nil)
+		lists.Update(benchStats(snap.HotSlice()))
+		require.NoError(b, snap.Close())
+		runtime.KeepAlive(lists)
+	}
+}
+
+func BenchmarkCorpus_Baseline_SelectAndScore(b *testing.B) {
+	entities := loadBenchEntities(b)
+	lists := index.NewLists(nil)
+	lists.Update(benchStats(entities))
+
+	query := search.Entity[search.Value]{
+		Name:   "Vladimir Putin",
+		Type:   search.EntityPerson,
+		Source: search.SourceUSOFAC,
+	}.Normalize()
+
+	b.ReportMetric(float64(len(entities)), "entities")
+	b.ResetTimer()
+
+	var hits int
+	for i := 0; i < b.N; i++ {
+		cands, err := lists.SelectCandidates(b.Context(), query)
+		require.NoError(b, err)
+		hits = len(cands)
+		for j := range cands {
+			_ = search.Similarity(query, cands[j])
+		}
+	}
+	b.ReportMetric(float64(hits), "candidates")
+}
+
+func BenchmarkCorpus_Tiered_SelectAndScore(b *testing.B) {
+	entities := loadBenchEntities(b)
+	snap, err := BuildSnapshot(filepath.Join(b.TempDir(), "corpus.snap"), entities)
+	require.NoError(b, err)
+	b.Cleanup(func() { snap.Close() })
+
+	lists := index.NewLists(nil)
+	lists.Update(benchStats(snap.HotSlice()))
+
+	query := search.Entity[search.Value]{
+		Name:   "Vladimir Putin",
+		Type:   search.EntityPerson,
+		Source: search.SourceUSOFAC,
+	}.Normalize()
+
+	b.ReportMetric(float64(len(entities)), "entities")
+	b.ResetTimer()
+
+	var hits int
+	for i := 0; i < b.N; i++ {
+		cands, err := lists.SelectCandidates(b.Context(), query)
+		require.NoError(b, err)
+		hits = len(cands)
+		for j := range cands {
+			_ = search.Similarity(query, cands[j])
+		}
+	}
+	b.ReportMetric(float64(hits), "candidates")
+}
+
+// --- helpers ---
+
+var (
+	benchEntitiesOnce sync.Once
+	benchEntities     []search.Entity[search.Value]
+	benchEntitiesErr  error
+)
+
+// loadBenchEntities returns a cached full OFAC corpus for latency benches.
+// Heap benches must call mustLoadOFACTestdata instead so SourceData can be dropped.
+func loadBenchEntities(b *testing.B) []search.Entity[search.Value] {
+	b.Helper()
+	benchEntitiesOnce.Do(func() {
+		benchEntities, benchEntitiesErr = loadOFACTestdata()
+	})
+	require.NoError(b, benchEntitiesErr)
+	require.NotEmpty(b, benchEntities)
+	return benchEntities
+}
+
+func mustLoadOFACTestdata(tb testing.TB) []search.Entity[search.Value] {
+	tb.Helper()
+	entities, err := loadOFACTestdata()
+	require.NoError(tb, err)
+	require.NotEmpty(tb, entities)
+	return entities
+}
+
+func loadOFACTestdata() ([]search.Entity[search.Value], error) {
+	pkg, err := fshelp.FindPkgDir()
+	if err != nil {
+		return nil, err
+	}
+	conf := download.Config{
+		InitialDataDirectory: filepath.Join(pkg, "sources", "ofac", "testdata"),
+		IncludedLists:        []search.SourceList{search.SourceUSOFAC},
+	}
+	dl, err := download.NewDownloader(log.NewNopLogger(), conf, nil)
+	if err != nil {
+		return nil, err
+	}
+	stats, err := dl.RefreshAll(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return stats.Entities, nil
+}
+
+func sampleQueries(tb testing.TB, entities []search.Entity[search.Value], n int) []search.Entity[search.Value] {
+	tb.Helper()
+	if n > len(entities) {
+		n = len(entities)
+	}
+	out := make([]search.Entity[search.Value], n)
+	step := len(entities) / n
+	if step < 1 {
+		step = 1
+	}
+	for i := 0; i < n; i++ {
+		e := entities[i*step]
+		e.SourceID = "" // avoid exact SourceID short-circuit in Similarity
+		e.SourceData = nil
+		out[i] = e
+	}
+	return out
+}
+
+func benchStats(entities []search.Entity[search.Value]) download.Stats {
+	lists := make(map[string]int)
+	for i := range entities {
+		lists[string(entities[i].Source)]++
+	}
+	return download.Stats{
+		Entities:  entities,
+		Lists:     lists,
+		StartedAt: time.Now().Add(-time.Second),
+		EndedAt:   time.Now(),
+	}
+}

--- a/internal/corpusfile/doc.go
+++ b/internal/corpusfile/doc.go
@@ -1,0 +1,78 @@
+// Package corpusfile sketches an on-disk corpus layout that keeps only the
+// search hot path in process memory and parks cold fields (primarily SourceData)
+// in an immutable snapshot file.
+//
+// # Motivation
+//
+// Watchman today holds []search.Entity in RAM, including SourceData (original
+// list payloads) that similarity scoring never reads. Refresh also double-buffers
+// the full object graph. This package explores a tiered layout:
+//
+//	HOT (RAM)     — fields Similarity / candidate indexes need
+//	COLD (disk)   — SourceData and other response-only payload
+//	INDEX (RAM)   — partitions, name tokens, crypto keys (unchanged model)
+//
+// # Snapshot file layout (v0 sketch)
+//
+//	Offset 0
+//	┌─────────────────────────────────────────────────────────────┐
+//	│ Header (128 bytes)                                          │
+//	│   magic[8] = "WMCORPUS"                                     │
+//	│   version u32, flags u32, entity_count u32                  │
+//	│   section offsets/lengths for string table, hot table,      │
+//	│   cold directory, cold blob region                          │
+//	├─────────────────────────────────────────────────────────────┤
+//	│ String table (optional densification)                       │
+//	│   u32 count, then repeated: u32 len + utf8 bytes            │
+//	│   Shared tokens: countries, programs, currencies, …         │
+//	├─────────────────────────────────────────────────────────────┤
+//	│ Hot table                                                   │
+//	│   entity_count records, each:                               │
+//	│     fixed header (type, source ids as string-table refs)    │
+//	│     varint section lengths + packed scoring fields          │
+//	│     cold_offset u64, cold_length u32  → into cold region    │
+//	├─────────────────────────────────────────────────────────────┤
+//	│ Cold directory                                              │
+//	│   entity_count × { offset u64, length u32, crc32 u32 }      │
+//	├─────────────────────────────────────────────────────────────┤
+//	│ Cold blob region                                            │
+//	│   per entity: length-prefixed payload (see ColdPayload)     │
+//	│   Payload encoding: codec flag + bytes (gob/zstd+gob/…)     │
+//	└─────────────────────────────────────────────────────────────┘
+//
+// Refresh writes corpus-vN.snap, fsyncs, atomically renames, then swaps the
+// open reader (same lifecycle as today's index.Lists.Update).
+//
+// # Field placement
+//
+// Hot (needed by pkg/search Similarity* and inverted indexes):
+//   - Name, Type, Source, SourceID
+//   - Person / Business / Organization / Aircraft / Vessel (IDs, titles, dates)
+//   - CryptoAddresses, Affiliations, SanctionsInfo, HistoricalInfo
+//   - PreparedFields (names, tokens, weights, prepared addresses, contact)
+//   - Addresses used only via PreparedFields.Addresses on the score path; the
+//     raw Addresses slice is still kept hot for API parity until a thinner
+//     response DTO exists
+//
+// Cold (not read during scoreSimilarityFast):
+//   - SourceData — original SDN/CSL/etc. structs
+//   - Raw Addresses (scoring uses PreparedFields.Addresses)
+//   - Raw phones/faxes/websites (phones/faxes score via PreparedFields.Contact)
+//   - SanctionsInfo.Description, Affiliation.Details, HistoricalInfo.Date
+//   - Type-level Name/AltNames mirrored by Entity.Name + PreparedFields
+//
+// Default cold codec is gob+zstd (see DefaultColdCodec).
+//
+// # Benchmarks
+//
+// Paired benches live in this package:
+//
+//	BenchmarkCorpus_Baseline_*  — today's full in-memory []Entity
+//	BenchmarkCorpus_Tiered_*    — hot slice in RAM + cold blobs on disk
+//
+// Run both and compare heap, file size, score latency, and hydrate cost:
+//
+//	go test ./internal/corpusfile/ -bench='BenchmarkCorpus_' -benchmem -count=5
+//
+// See layout.go and split.go for the concrete types used by the prototype.
+package corpusfile

--- a/internal/corpusfile/errors.go
+++ b/internal/corpusfile/errors.go
@@ -1,0 +1,25 @@
+package corpusfile
+
+import "fmt"
+
+type formatError struct {
+	msg string
+}
+
+func (e formatError) Error() string { return "corpusfile: " + e.msg }
+
+func errShort(what string, want, got int) error {
+	return formatError{msg: fmt.Sprintf("short %s: need %d bytes, got %d", what, want, got)}
+}
+
+func errBadMagic(got string) error {
+	return formatError{msg: fmt.Sprintf("bad magic %q, want %q", got, Magic)}
+}
+
+func errCodec(c uint8) error {
+	return formatError{msg: fmt.Sprintf("unsupported cold codec %d", c)}
+}
+
+func errEntityCount(want, got int) error {
+	return formatError{msg: fmt.Sprintf("entity count mismatch: header %d, got %d", want, got)}
+}

--- a/internal/corpusfile/layout.go
+++ b/internal/corpusfile/layout.go
@@ -1,0 +1,136 @@
+package corpusfile
+
+import "encoding/binary"
+
+// File format constants for the corpus snapshot sketch.
+// The on-disk writer/reader in this package implements a pragmatic subset:
+// header + cold directory + cold blobs, with hot entities still held as Go
+// values in RAM (SourceData stripped). A denser binary hot table / string
+// table can replace that without changing ColdPayload.
+
+const (
+	// Magic identifies a Watchman corpus snapshot.
+	Magic = "WMCORPUS"
+
+	// Version is the snapshot format version written by this package.
+	Version uint32 = 1
+
+	// HeaderSize is the fixed header length in bytes.
+	HeaderSize = 128
+
+	// Codec identity for cold payloads.
+	CodecGob uint8 = 1
+	// CodecGobZstd is reserved for compressed cold blobs (not required for baseline).
+	CodecGobZstd uint8 = 2
+)
+
+// Header is the fixed 128-byte file preamble.
+//
+// Binary layout (little-endian):
+//
+//	0   magic[8]
+//	8   version u32
+//	12  flags u32
+//	16  entity_count u32
+//	20  reserved u32
+//	24  string_table_off u64
+//	32  string_table_len u64
+//	40  hot_table_off u64
+//	48  hot_table_len u64
+//	56  cold_dir_off u64
+//	64  cold_dir_len u64
+//	72  cold_blob_off u64
+//	80  cold_blob_len u64
+//	88  created_unix_nano i64
+//	96  reserved[32]
+type Header struct {
+	Magic         [8]byte
+	Version       uint32
+	Flags         uint32
+	EntityCount   uint32
+	_             uint32
+	StringTableOff uint64
+	StringTableLen uint64
+	HotTableOff   uint64
+	HotTableLen   uint64
+	ColdDirOff    uint64
+	ColdDirLen    uint64
+	ColdBlobOff   uint64
+	ColdBlobLen   uint64
+	CreatedUnixNano int64
+}
+
+// Flag bits for Header.Flags.
+const (
+	FlagHotInFile uint32 = 1 << iota // hot table present on disk (future)
+	FlagHasStringTable
+)
+
+// ColdDirEntry locates one entity's cold blob inside the blob region.
+// On disk: offset u64, length u32, crc32 u32 (16 bytes).
+type ColdDirEntry struct {
+	Offset uint64
+	Length uint32
+	CRC32  uint32
+}
+
+const coldDirEntrySize = 16
+
+// PutHeader serializes h into dst, which must be at least HeaderSize bytes.
+func PutHeader(dst []byte, h Header) {
+	if len(dst) < HeaderSize {
+		panic("corpusfile: header buffer too small")
+	}
+	copy(dst[0:8], h.Magic[:])
+	binary.LittleEndian.PutUint32(dst[8:12], h.Version)
+	binary.LittleEndian.PutUint32(dst[12:16], h.Flags)
+	binary.LittleEndian.PutUint32(dst[16:20], h.EntityCount)
+	binary.LittleEndian.PutUint64(dst[24:32], h.StringTableOff)
+	binary.LittleEndian.PutUint64(dst[32:40], h.StringTableLen)
+	binary.LittleEndian.PutUint64(dst[40:48], h.HotTableOff)
+	binary.LittleEndian.PutUint64(dst[48:56], h.HotTableLen)
+	binary.LittleEndian.PutUint64(dst[56:64], h.ColdDirOff)
+	binary.LittleEndian.PutUint64(dst[64:72], h.ColdDirLen)
+	binary.LittleEndian.PutUint64(dst[72:80], h.ColdBlobOff)
+	binary.LittleEndian.PutUint64(dst[80:88], h.ColdBlobLen)
+	binary.LittleEndian.PutUint64(dst[88:96], uint64(h.CreatedUnixNano))
+}
+
+// ReadHeader parses a Header from src.
+func ReadHeader(src []byte) (Header, error) {
+	var h Header
+	if len(src) < HeaderSize {
+		return h, errShort("header", HeaderSize, len(src))
+	}
+	copy(h.Magic[:], src[0:8])
+	if string(h.Magic[:]) != Magic {
+		return h, errBadMagic(string(h.Magic[:]))
+	}
+	h.Version = binary.LittleEndian.Uint32(src[8:12])
+	h.Flags = binary.LittleEndian.Uint32(src[12:16])
+	h.EntityCount = binary.LittleEndian.Uint32(src[16:20])
+	h.StringTableOff = binary.LittleEndian.Uint64(src[24:32])
+	h.StringTableLen = binary.LittleEndian.Uint64(src[32:40])
+	h.HotTableOff = binary.LittleEndian.Uint64(src[40:48])
+	h.HotTableLen = binary.LittleEndian.Uint64(src[48:56])
+	h.ColdDirOff = binary.LittleEndian.Uint64(src[56:64])
+	h.ColdDirLen = binary.LittleEndian.Uint64(src[64:72])
+	h.ColdBlobOff = binary.LittleEndian.Uint64(src[72:80])
+	h.ColdBlobLen = binary.LittleEndian.Uint64(src[80:88])
+	h.CreatedUnixNano = int64(binary.LittleEndian.Uint64(src[88:96]))
+	return h, nil
+}
+
+func putColdDirEntry(dst []byte, e ColdDirEntry) {
+	binary.LittleEndian.PutUint64(dst[0:8], e.Offset)
+	binary.LittleEndian.PutUint32(dst[8:12], e.Length)
+	binary.LittleEndian.PutUint32(dst[12:16], e.CRC32)
+}
+
+func readColdDirEntry(src []byte) ColdDirEntry {
+	return ColdDirEntry{
+		Offset: binary.LittleEndian.Uint64(src[0:8]),
+		Length: binary.LittleEndian.Uint32(src[8:12]),
+		CRC32:  binary.LittleEndian.Uint32(src[12:16]),
+	}
+}

--- a/internal/corpusfile/memory_report_test.go
+++ b/internal/corpusfile/memory_report_test.go
@@ -1,0 +1,67 @@
+package corpusfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCorpus_MemoryReport prints a GC-stable before/after size comparison using
+// gob-encoded byte lengths (see MeasureSizes) plus on-disk snapshot size.
+//
+//	go test ./internal/corpusfile/ -run TestCorpus_MemoryReport -v
+func TestCorpus_MemoryReport(t *testing.T) {
+	entities := mustLoadOFACTestdata(t)
+
+	breakdown, err := MeasureFieldBreakdown(entities)
+	require.NoError(t, err)
+	t.Logf("field breakdown (OFAC package testdata)\n%s", breakdown.String())
+
+	report, err := MeasureSizes(entities)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "corpus.snap")
+	snap, err := BuildSnapshot(path, entities)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	size, err := snap.FileSize()
+	require.NoError(t, err)
+	report.SnapshotFileBytes = size
+
+	t.Logf("corpus size report (OFAC package testdata)")
+	t.Logf("  %s", report.String())
+	t.Logf("BASELINE retained working set proxy: full gob = %.2f MB", float64(report.FullEntityBytes)/(1<<20))
+	t.Logf("TIERED retained working set proxy:   hot gob  = %.2f MB + cold file %.2f MB",
+		float64(report.HotBytes)/(1<<20), float64(report.SnapshotFileBytes)/(1<<20))
+	if report.FullEntityBytes > 0 {
+		saved := float64(report.FullEntityBytes-report.HotBytes) / float64(report.FullEntityBytes) * 100
+		t.Logf("cold-stripped share of full gob:    %.1f%% (%.2f MB)",
+			saved, float64(report.FullEntityBytes-report.HotBytes)/(1<<20))
+	}
+}
+
+func TestEncodeCold_ZstdSmallerThanGob(t *testing.T) {
+	entities := mustLoadOFACTestdata(t)
+	require.Greater(t, len(entities), 100)
+
+	var gobTotal, zstdTotal int64
+	for i := 0; i < 500 && i < len(entities); i++ {
+		cold := SplitEntity(entities[i]).Cold
+		g, err := EncodeColdCodec(cold, CodecGob)
+		require.NoError(t, err)
+		z, err := EncodeColdCodec(cold, CodecGobZstd)
+		require.NoError(t, err)
+		gobTotal += int64(len(g))
+		zstdTotal += int64(len(z))
+
+		// Round-trip zstd
+		decoded, err := DecodeCold(z)
+		require.NoError(t, err)
+		require.Equal(t, cold.SourceData, decoded.SourceData)
+	}
+	t.Logf("sample cold payloads: gob=%.2fMB zstd=%.2fMB ratio=%.2f",
+		float64(gobTotal)/(1<<20), float64(zstdTotal)/(1<<20), float64(zstdTotal)/float64(gobTotal))
+	require.Less(t, zstdTotal, gobTotal)
+}

--- a/internal/corpusfile/register_ofac.go
+++ b/internal/corpusfile/register_ofac.go
@@ -1,0 +1,17 @@
+package corpusfile
+
+import (
+	"encoding/gob"
+
+	"github.com/moov-io/watchman/pkg/sources/ofac"
+)
+
+func init() {
+	// OFAC SourceData types used when building snapshots from ofactest corpora.
+	gob.Register(ofac.SDN{})
+	gob.Register(ofac.Address{})
+	gob.Register(ofac.AlternateIdentity{})
+	gob.Register(ofac.SDNComments{})
+	gob.Register([]ofac.Address{})
+	gob.Register([]ofac.AlternateIdentity{})
+}

--- a/internal/corpusfile/size.go
+++ b/internal/corpusfile/size.go
@@ -1,0 +1,102 @@
+package corpusfile
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"reflect"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// SizeReport is a stable, GC-independent estimate of corpus footprint.
+// Sizes are gob-encoded byte lengths (a consistent proxy, not RSS).
+type SizeReport struct {
+	Entities int
+
+	// FullEntityBytes is gob size of the production []Entity (with SourceData).
+	FullEntityBytes int64
+
+	// HotBytes is gob size of entities with SourceData cleared.
+	HotBytes int64
+
+	// ColdBytes is gob size of cold payloads only (pre-file framing).
+	ColdBytes int64
+
+	// SnapshotFileBytes is the on-disk snapshot size when built (0 if not built).
+	SnapshotFileBytes int64
+}
+
+func (r SizeReport) String() string {
+	n := float64(r.Entities)
+	if n < 1 {
+		n = 1
+	}
+	return fmt.Sprintf(
+		"entities=%d full=%.2fMB (%.0fB/e) hot=%.2fMB (%.0fB/e) cold=%.2fMB (%.0fB/e) snap=%.2fMB cold_frac=%.1f%%",
+		r.Entities,
+		float64(r.FullEntityBytes)/(1<<20), float64(r.FullEntityBytes)/n,
+		float64(r.HotBytes)/(1<<20), float64(r.HotBytes)/n,
+		float64(r.ColdBytes)/(1<<20), float64(r.ColdBytes)/n,
+		float64(r.SnapshotFileBytes)/(1<<20),
+		100*float64(r.ColdBytes)/float64(max64(r.FullEntityBytes, 1)),
+	)
+}
+
+// MeasureSizes gob-encodes full/hot/cold views for a stable size comparison.
+func MeasureSizes(entities []search.Entity[search.Value]) (SizeReport, error) {
+	var r SizeReport
+	r.Entities = len(entities)
+
+	full, err := gobSize(entities)
+	if err != nil {
+		return r, fmt.Errorf("full: %w", err)
+	}
+	r.FullEntityBytes = full
+
+	hot := make([]search.Entity[search.Value], len(entities))
+	var coldTotal int64
+	for i := range entities {
+		split := SplitEntity(entities[i])
+		hot[i] = split.Hot
+		raw, err := EncodeCold(split.Cold)
+		if err != nil {
+			return r, fmt.Errorf("cold %d: %w", i, err)
+		}
+		coldTotal += int64(len(raw))
+	}
+	r.ColdBytes = coldTotal
+
+	hotBytes, err := gobSize(hot)
+	if err != nil {
+		return r, fmt.Errorf("hot: %w", err)
+	}
+	r.HotBytes = hotBytes
+	return r, nil
+}
+
+func gobSize(v any) (int64, error) {
+	if v == nil {
+		return 0, nil
+	}
+	// gob panics on typed nil pointers (e.g. (*Person)(nil) in interface{}).
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+		if rv.IsNil() {
+			return 0, nil
+		}
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(v); err != nil {
+		return 0, err
+	}
+	return int64(buf.Len()), nil
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/corpusfile/snapshot.go
+++ b/internal/corpusfile/snapshot.go
@@ -1,0 +1,216 @@
+package corpusfile
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+// Snapshot is an opened corpus: hot entities in RAM, cold blobs on disk.
+//
+// This is the tiered prototype used by BenchmarkCorpus_Tiered_*. Production
+// wiring would replace index.corpus.entities with Snapshot.Hot (or a denser
+// binary hot table) and call Hydrate only for top-N API results.
+type Snapshot struct {
+	path string
+	hdr  Header
+	hot  []search.Entity[search.Value]
+	dir  []ColdDirEntry
+
+	// f is held so cold reads stay valid; Close releases it.
+	f *os.File
+}
+
+// BuildSnapshot splits entities, writes cold data to path, and returns an open Snapshot.
+// Hot records stay in process memory with SourceData cleared.
+func BuildSnapshot(path string, entities []search.Entity[search.Value]) (*Snapshot, error) {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir snapshot dir: %w", err)
+		}
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create snapshot: %w", err)
+	}
+	ok := false
+	defer func() {
+		if !ok {
+			f.Close()
+			os.Remove(path)
+		}
+	}()
+
+	n := len(entities)
+	hot := make([]search.Entity[search.Value], n)
+	dir := make([]ColdDirEntry, n)
+
+	// Layout:
+	//   [Header 128]
+	//   [Cold directory n*16]
+	//   [Cold blobs …]
+	coldDirOff := uint64(HeaderSize)
+	coldDirLen := uint64(n * coldDirEntrySize)
+	coldBlobOff := coldDirOff + coldDirLen
+
+	if _, err := f.Seek(int64(coldBlobOff), io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	var blobLen uint64
+	for i := range entities {
+		split := SplitEntity(entities[i])
+		hot[i] = split.Hot
+
+		raw, err := EncodeCold(split.Cold)
+		if err != nil {
+			return nil, fmt.Errorf("entity %d: %w", i, err)
+		}
+		dir[i] = ColdDirEntry{
+			Offset: blobLen,
+			Length: uint32(len(raw)),
+			CRC32:  blobCRC(raw),
+		}
+		if _, err := f.Write(raw); err != nil {
+			return nil, fmt.Errorf("write cold %d: %w", i, err)
+		}
+		blobLen += uint64(len(raw))
+	}
+
+	// Write cold directory
+	dirBuf := make([]byte, coldDirLen)
+	for i := range dir {
+		putColdDirEntry(dirBuf[i*coldDirEntrySize:], dir[i])
+	}
+	if _, err := f.WriteAt(dirBuf, int64(coldDirOff)); err != nil {
+		return nil, fmt.Errorf("write cold dir: %w", err)
+	}
+
+	hdr := Header{
+		Version:         Version,
+		EntityCount:     uint32(n),
+		ColdDirOff:      coldDirOff,
+		ColdDirLen:      coldDirLen,
+		ColdBlobOff:     coldBlobOff,
+		ColdBlobLen:     blobLen,
+		CreatedUnixNano: nowUnixNano(),
+	}
+	copy(hdr.Magic[:], Magic)
+
+	var hdrBuf [HeaderSize]byte
+	PutHeader(hdrBuf[:], hdr)
+	if _, err := f.WriteAt(hdrBuf[:], 0); err != nil {
+		return nil, fmt.Errorf("write header: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		return nil, err
+	}
+
+	ok = true
+	return &Snapshot{
+		path: path,
+		hdr:  hdr,
+		hot:  hot,
+		dir:  dir,
+		f:    f,
+	}, nil
+}
+
+// OpenSnapshot loads hot entities from a side-car is not supported yet; use BuildSnapshot.
+// Open reopens cold storage for an existing file when hot is provided separately.
+func OpenSnapshot(path string, hot []search.Entity[search.Value]) (*Snapshot, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	var hdrBuf [HeaderSize]byte
+	if _, err := io.ReadFull(f, hdrBuf[:]); err != nil {
+		f.Close()
+		return nil, err
+	}
+	hdr, err := ReadHeader(hdrBuf[:])
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if int(hdr.EntityCount) != len(hot) {
+		f.Close()
+		return nil, errEntityCount(int(hdr.EntityCount), len(hot))
+	}
+
+	dirBuf := make([]byte, hdr.ColdDirLen)
+	if _, err := f.ReadAt(dirBuf, int64(hdr.ColdDirOff)); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("read cold dir: %w", err)
+	}
+	dir := make([]ColdDirEntry, hdr.EntityCount)
+	for i := range dir {
+		dir[i] = readColdDirEntry(dirBuf[i*coldDirEntrySize:])
+	}
+
+	return &Snapshot{path: path, hdr: hdr, hot: hot, dir: dir, f: f}, nil
+}
+
+// Close releases the underlying file.
+func (s *Snapshot) Close() error {
+	if s == nil || s.f == nil {
+		return nil
+	}
+	err := s.f.Close()
+	s.f = nil
+	return err
+}
+
+// Len returns entity count.
+func (s *Snapshot) Len() int { return len(s.hot) }
+
+// Hot returns the in-memory scoring entity at i (SourceData is nil).
+func (s *Snapshot) Hot(i int) search.Entity[search.Value] { return s.hot[i] }
+
+// HotSlice returns the backing hot slice (read-only by convention).
+func (s *Snapshot) HotSlice() []search.Entity[search.Value] { return s.hot }
+
+// FileSize returns the snapshot file size in bytes.
+func (s *Snapshot) FileSize() (int64, error) {
+	st, err := os.Stat(s.path)
+	if err != nil {
+		return 0, err
+	}
+	return st.Size(), nil
+}
+
+// Header returns the parsed file header.
+func (s *Snapshot) Header() Header { return s.hdr }
+
+// ReadCold loads and decodes the cold payload for entity i.
+func (s *Snapshot) ReadCold(i int) (ColdPayload, error) {
+	if i < 0 || i >= len(s.dir) {
+		return ColdPayload{}, fmt.Errorf("corpusfile: index %d out of range", i)
+	}
+	ent := s.dir[i]
+	buf := make([]byte, ent.Length)
+	off := int64(s.hdr.ColdBlobOff + ent.Offset)
+	if _, err := s.f.ReadAt(buf, off); err != nil {
+		return ColdPayload{}, fmt.Errorf("read cold %d: %w", i, err)
+	}
+	if crc := blobCRC(buf); crc != ent.CRC32 {
+		return ColdPayload{}, fmt.Errorf("corpusfile: cold %d crc mismatch", i)
+	}
+	return DecodeCold(buf)
+}
+
+// Hydrate returns a full entity (hot + cold SourceData) for API responses.
+func (s *Snapshot) Hydrate(i int) (search.Entity[search.Value], error) {
+	cold, err := s.ReadCold(i)
+	if err != nil {
+		return search.Entity[search.Value]{}, err
+	}
+	return Reattach(s.hot[i], cold), nil
+}
+
+// Path returns the snapshot file path.
+func (s *Snapshot) Path() string { return s.path }

--- a/internal/corpusfile/snapshot_test.go
+++ b/internal/corpusfile/snapshot_test.go
@@ -1,0 +1,126 @@
+package corpusfile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/moov-io/watchman/internal/ofactest"
+	"github.com/moov-io/watchman/pkg/search"
+	"github.com/moov-io/watchman/pkg/sources/ofac"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitEntity_ClearsSourceData(t *testing.T) {
+	e := ofactest.FindEntity(t, "29702")
+	require.NotNil(t, e.SourceData)
+
+	split := SplitEntity(e)
+	require.Nil(t, split.Hot.SourceData)
+	require.NotNil(t, split.Cold.SourceData)
+	// Raw display fields move cold; prepared scoring fields stay hot.
+	require.Nil(t, split.Hot.Addresses)
+	require.Equal(t, e.Addresses, split.Cold.Addresses)
+	require.Equal(t, e.PreparedFields.Addresses, split.Hot.PreparedFields.Addresses)
+	require.Empty(t, split.Hot.Contact.PhoneNumbers)
+	require.Equal(t, e.Contact.PhoneNumbers, split.Cold.PhoneNumbers)
+	require.Equal(t, e.PreparedFields.Contact.PhoneNumbers, split.Hot.PreparedFields.Contact.PhoneNumbers)
+
+	// Scoring fields remain
+	require.Equal(t, e.Name, split.Hot.Name)
+	require.Equal(t, e.Type, split.Hot.Type)
+	require.Equal(t, e.PreparedFields.Name, split.Hot.PreparedFields.Name)
+
+	// Similarity must not depend on cold fields
+	other := ofactest.FindEntity(t, "44525")
+	require.InDelta(t,
+		search.Similarity(e, other),
+		search.Similarity(split.Hot, SplitEntity(other).Hot),
+		1e-9,
+	)
+
+	full := Reattach(split.Hot, split.Cold)
+	require.Equal(t, e.SourceData, full.SourceData)
+	require.Equal(t, e.Addresses, full.Addresses)
+	require.Equal(t, e.Contact.PhoneNumbers, full.Contact.PhoneNumbers)
+}
+
+func TestSnapshot_RoundTrip(t *testing.T) {
+	entities := loadOFACEntities(t)
+	require.NotEmpty(t, entities)
+
+	path := filepath.Join(t.TempDir(), "corpus.snap")
+	snap, err := BuildSnapshot(path, entities)
+	require.NoError(t, err)
+	t.Cleanup(func() { snap.Close() })
+
+	require.Equal(t, len(entities), snap.Len())
+	require.Equal(t, uint32(Version), snap.Header().Version)
+
+	// Spot-check a few entities
+	for _, id := range []string{"29702", "44525", "50972"} {
+		idx := findBySourceID(entities, id)
+		require.GreaterOrEqual(t, idx, 0, "missing %s", id)
+
+		hot := snap.Hot(idx)
+		require.Nil(t, hot.SourceData)
+		require.Equal(t, entities[idx].Name, hot.Name)
+
+		// Similarity must match baseline (SourceData unused)
+		base := search.Similarity(entities[idx], entities[(idx+1)%len(entities)])
+		got := search.Similarity(hot, snap.Hot((idx+1)%len(entities)))
+		require.Equal(t, base, got)
+
+		hydrated, err := snap.Hydrate(idx)
+		require.NoError(t, err)
+		sdn, ok := hydrated.SourceData.(ofac.SDN)
+		require.True(t, ok)
+		require.Equal(t, id, sdn.EntityID)
+	}
+
+	size, err := snap.FileSize()
+	require.NoError(t, err)
+	require.Greater(t, size, int64(HeaderSize))
+	t.Logf("snapshot: %d entities, file=%d bytes (%.2f MB)", snap.Len(), size, float64(size)/(1<<20))
+}
+
+func TestHeader_RoundTrip(t *testing.T) {
+	h := Header{
+		Version:         Version,
+		Flags:           FlagHasStringTable,
+		EntityCount:     42,
+		StringTableOff:  128,
+		StringTableLen:  1000,
+		ColdDirOff:      1128,
+		ColdDirLen:      42 * coldDirEntrySize,
+		ColdBlobOff:     2000,
+		ColdBlobLen:     99999,
+		CreatedUnixNano: 1234567890,
+	}
+	copy(h.Magic[:], Magic)
+
+	var buf [HeaderSize]byte
+	PutHeader(buf[:], h)
+	got, err := ReadHeader(buf[:])
+	require.NoError(t, err)
+	require.Equal(t, h, got)
+}
+
+func loadOFACEntities(tb testing.TB) []search.Entity[search.Value] {
+	tb.Helper()
+	// Warm ofactest (small fixture for unit tests is fine).
+	_ = ofactest.FindEntity(tb, "29702")
+	stats, err := ofactest.GetDownloader(tb).RefreshAll(tb.Context())
+	require.NoError(tb, err)
+	require.NotEmpty(tb, stats.Entities)
+	return stats.Entities
+}
+
+func findBySourceID(entities []search.Entity[search.Value], id string) int {
+	for i := range entities {
+		if entities[i].SourceID == id {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/corpusfile/split.go
+++ b/internal/corpusfile/split.go
@@ -1,0 +1,331 @@
+package corpusfile
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"hash/crc32"
+	"sync"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/moov-io/watchman/pkg/search"
+)
+
+func init() {
+	// SourceData is interface{}; register concrete list types used in tests/prod mappers.
+	// Additional source types can register in their packages via gob.Register.
+	gob.Register(map[string]interface{}{})
+	gob.Register(map[string]string{})
+}
+
+// DefaultColdCodec is used when EncodeCold is called without an explicit codec.
+// Gob+zstd is the production default: smaller cold files, modest hydrate CPU.
+var DefaultColdCodec uint8 = CodecGobZstd
+
+// ColdPayload is the per-entity blob stored outside the hot working set.
+// Only fields that scoreSimilarityFast does not need on the index side belong here.
+//
+// Hot path keeps PreparedFields (names, tokens, prepared addresses, normalized phones)
+// plus emails (exact match still reads Contact.EmailAddresses), crypto, IDs, etc.
+type ColdPayload struct {
+	// SourceData is the original list record (OFAC SDN, CSL rows, etc.).
+	SourceData any
+
+	// Display / API fields not required for scoring once PreparedFields exist.
+	Addresses []search.Address
+	// Raw phone/fax/websites; scoring uses PreparedFields.Contact for phone/fax.
+	// Emails stay hot (exact match reads Contact.EmailAddresses).
+	PhoneNumbers []string
+	FaxNumbers   []string
+	Websites     []string
+
+	// Supporting text stripped from hot sanctions/affiliation/historical rows.
+	SanctionsDescription string
+	AffiliationDetails   []string // parallel to hot Affiliations order
+	HistoricalDates      []time.Time
+
+	// Type-level name mirrors (Entity.Name + PreparedFields cover scoring).
+	PersonName         string
+	PersonAltNames     []string
+	BusinessName       string
+	BusinessAltNames   []string
+	OrganizationName   string
+	OrganizationAltNames []string
+	AircraftName       string
+	AircraftAltNames   []string
+	VesselName         string
+	VesselAltNames     []string
+}
+
+// SplitResult is one entity divided into hot (scoring) and cold (response) parts.
+type SplitResult struct {
+	// Hot is a full Entity suitable for Similarity, with cold fields cleared.
+	Hot search.Entity[search.Value]
+
+	// Cold holds fields needed to rehydrate API responses.
+	Cold ColdPayload
+}
+
+// SplitEntity moves non-scoring fields into ColdPayload.
+// The returned Hot entity is safe for pkg/search.Similarity* paths.
+func SplitEntity(e search.Entity[search.Value]) SplitResult {
+	cold := ColdPayload{
+		SourceData:   e.SourceData,
+		Addresses:    e.Addresses,
+		PhoneNumbers: e.Contact.PhoneNumbers,
+		FaxNumbers:   e.Contact.FaxNumbers,
+		Websites:     e.Contact.Websites,
+	}
+
+	hot := e
+	hot.SourceData = nil
+	hot.Addresses = nil
+	hot.Contact.PhoneNumbers = nil
+	hot.Contact.FaxNumbers = nil
+	hot.Contact.Websites = nil
+	// Emails remain on hot.Contact for exact match.
+
+	if e.SanctionsInfo != nil {
+		cold.SanctionsDescription = e.SanctionsInfo.Description
+		if e.SanctionsInfo.Description != "" {
+			cp := *e.SanctionsInfo
+			cp.Description = ""
+			hot.SanctionsInfo = &cp
+		}
+	}
+
+	if n := len(e.Affiliations); n > 0 {
+		cold.AffiliationDetails = make([]string, n)
+		hot.Affiliations = make([]search.Affiliation, n)
+		for i, a := range e.Affiliations {
+			cold.AffiliationDetails[i] = a.Details
+			hot.Affiliations[i] = search.Affiliation{
+				EntityName: a.EntityName,
+				Type:       a.Type,
+				// Details cold
+			}
+		}
+	}
+
+	if n := len(e.HistoricalInfo); n > 0 {
+		cold.HistoricalDates = make([]time.Time, n)
+		hot.HistoricalInfo = make([]search.HistoricalInfo, n)
+		for i, h := range e.HistoricalInfo {
+			cold.HistoricalDates[i] = h.Date
+			hot.HistoricalInfo[i] = search.HistoricalInfo{
+				Type:  h.Type,
+				Value: h.Value,
+			}
+		}
+	}
+
+	// Type-level Name/AltNames are mirrored in Entity.Name + PreparedFields.
+	if e.Person != nil {
+		cold.PersonName = e.Person.Name
+		cold.PersonAltNames = e.Person.AltNames
+		p := *e.Person
+		p.Name = ""
+		p.AltNames = nil
+		hot.Person = &p
+	}
+	if e.Business != nil {
+		cold.BusinessName = e.Business.Name
+		cold.BusinessAltNames = e.Business.AltNames
+		b := *e.Business
+		b.Name = ""
+		b.AltNames = nil
+		hot.Business = &b
+	}
+	if e.Organization != nil {
+		cold.OrganizationName = e.Organization.Name
+		cold.OrganizationAltNames = e.Organization.AltNames
+		o := *e.Organization
+		o.Name = ""
+		o.AltNames = nil
+		hot.Organization = &o
+	}
+	if e.Aircraft != nil {
+		cold.AircraftName = e.Aircraft.Name
+		cold.AircraftAltNames = e.Aircraft.AltNames
+		a := *e.Aircraft
+		a.Name = ""
+		a.AltNames = nil
+		hot.Aircraft = &a
+	}
+	if e.Vessel != nil {
+		cold.VesselName = e.Vessel.Name
+		cold.VesselAltNames = e.Vessel.AltNames
+		v := *e.Vessel
+		v.Name = ""
+		v.AltNames = nil
+		hot.Vessel = &v
+	}
+
+	return SplitResult{Hot: hot, Cold: cold}
+}
+
+// Reattach merges a cold payload back onto a hot entity for API responses.
+func Reattach(hot search.Entity[search.Value], cold ColdPayload) search.Entity[search.Value] {
+	out := hot
+	out.SourceData = cold.SourceData
+	out.Addresses = cold.Addresses
+	out.Contact.PhoneNumbers = cold.PhoneNumbers
+	out.Contact.FaxNumbers = cold.FaxNumbers
+	out.Contact.Websites = cold.Websites
+
+	if out.SanctionsInfo != nil && cold.SanctionsDescription != "" {
+		cp := *out.SanctionsInfo
+		cp.Description = cold.SanctionsDescription
+		out.SanctionsInfo = &cp
+	} else if out.SanctionsInfo == nil && cold.SanctionsDescription != "" {
+		out.SanctionsInfo = &search.SanctionsInfo{Description: cold.SanctionsDescription}
+	}
+
+	if len(out.Affiliations) > 0 && len(cold.AffiliationDetails) > 0 {
+		affs := make([]search.Affiliation, len(out.Affiliations))
+		copy(affs, out.Affiliations)
+		for i := range affs {
+			if i < len(cold.AffiliationDetails) {
+				affs[i].Details = cold.AffiliationDetails[i]
+			}
+		}
+		out.Affiliations = affs
+	}
+
+	if len(out.HistoricalInfo) > 0 && len(cold.HistoricalDates) > 0 {
+		hist := make([]search.HistoricalInfo, len(out.HistoricalInfo))
+		copy(hist, out.HistoricalInfo)
+		for i := range hist {
+			if i < len(cold.HistoricalDates) {
+				hist[i].Date = cold.HistoricalDates[i]
+			}
+		}
+		out.HistoricalInfo = hist
+	}
+
+	if out.Person != nil {
+		p := *out.Person
+		p.Name = cold.PersonName
+		p.AltNames = cold.PersonAltNames
+		out.Person = &p
+	}
+	if out.Business != nil {
+		b := *out.Business
+		b.Name = cold.BusinessName
+		b.AltNames = cold.BusinessAltNames
+		out.Business = &b
+	}
+	if out.Organization != nil {
+		o := *out.Organization
+		o.Name = cold.OrganizationName
+		o.AltNames = cold.OrganizationAltNames
+		out.Organization = &o
+	}
+	if out.Aircraft != nil {
+		a := *out.Aircraft
+		a.Name = cold.AircraftName
+		a.AltNames = cold.AircraftAltNames
+		out.Aircraft = &a
+	}
+	if out.Vessel != nil {
+		v := *out.Vessel
+		v.Name = cold.VesselName
+		v.AltNames = cold.VesselAltNames
+		out.Vessel = &v
+	}
+
+	return out
+}
+
+// EncodeCold serializes a cold payload using DefaultColdCodec.
+func EncodeCold(c ColdPayload) ([]byte, error) {
+	return EncodeColdCodec(c, DefaultColdCodec)
+}
+
+// EncodeColdCodec serializes with an explicit codec byte.
+func EncodeColdCodec(c ColdPayload, codec uint8) ([]byte, error) {
+	var body bytes.Buffer
+	if err := gob.NewEncoder(&body).Encode(c); err != nil {
+		return nil, fmt.Errorf("gob encode cold: %w", err)
+	}
+
+	switch codec {
+	case CodecGob:
+		out := make([]byte, 1+body.Len())
+		out[0] = CodecGob
+		copy(out[1:], body.Bytes())
+		return out, nil
+
+	case CodecGobZstd:
+		enc := getZstdEncoder()
+		compressed := enc.EncodeAll(body.Bytes(), make([]byte, 0, body.Len()/2))
+		putZstdEncoder(enc)
+		out := make([]byte, 1+len(compressed))
+		out[0] = CodecGobZstd
+		copy(out[1:], compressed)
+		return out, nil
+
+	default:
+		return nil, errCodec(codec)
+	}
+}
+
+// DecodeCold parses a cold blob produced by EncodeCold / EncodeColdCodec.
+func DecodeCold(b []byte) (ColdPayload, error) {
+	var c ColdPayload
+	if len(b) < 1 {
+		return c, errShort("cold blob", 1, len(b))
+	}
+
+	payload := b[1:]
+	switch b[0] {
+	case CodecGob:
+		// raw gob
+	case CodecGobZstd:
+		dec := getZstdDecoder()
+		var err error
+		payload, err = dec.DecodeAll(payload, make([]byte, 0, len(payload)*2))
+		putZstdDecoder(dec)
+		if err != nil {
+			return c, fmt.Errorf("zstd decode: %w", err)
+		}
+	default:
+		return c, errCodec(b[0])
+	}
+
+	if err := gob.NewDecoder(bytes.NewReader(payload)).Decode(&c); err != nil {
+		return c, fmt.Errorf("gob decode cold: %w", err)
+	}
+	return c, nil
+}
+
+var (
+	zstdEncPool = sync.Pool{New: func() any {
+		enc, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		if err != nil {
+			panic(err) //nolint:forbidigo // constructor failure is programmer/env error
+		}
+		return enc
+	}}
+	zstdDecPool = sync.Pool{New: func() any {
+		dec, err := zstd.NewReader(nil)
+		if err != nil {
+			panic(err) //nolint:forbidigo
+		}
+		return dec
+	}}
+)
+
+func getZstdEncoder() *zstd.Encoder { return zstdEncPool.Get().(*zstd.Encoder) }
+func putZstdEncoder(e *zstd.Encoder) { zstdEncPool.Put(e) }
+func getZstdDecoder() *zstd.Decoder  { return zstdDecPool.Get().(*zstd.Decoder) }
+func putZstdDecoder(d *zstd.Decoder) { zstdDecPool.Put(d) }
+
+// crc of blob bytes (for directory integrity checks).
+func blobCRC(b []byte) uint32 {
+	return crc32.ChecksumIEEE(b)
+}
+
+// nowUnixNano is broken out for tests.
+var nowUnixNano = func() int64 { return time.Now().UnixNano() }

--- a/internal/corpusfile/testdata/baseline_ofac.txt
+++ b/internal/corpusfile/testdata/baseline_ofac.txt
@@ -1,0 +1,54 @@
+# Watchman corpusfile baseline — OFAC package testdata (pkg/sources/ofac/testdata)
+# Machine: Apple M4 Max, darwin/arm64
+# Updated: 2026-07-31 (deeper cold split + gob/zstd)
+# Re-run:
+#   go test ./internal/corpusfile/ -run TestCorpus_MemoryReport -v
+#   go test ./internal/corpusfile/ -bench='BenchmarkCorpus_' -benchmem -count=5
+#
+# Size proxies use gob-encoded byte lengths (GC-stable), not RSS.
+
+## Field breakdown (isolated gob of each group; sums > full entity gob)
+entities=16989 total=33.61MB
+  PreparedFields   13.47 MB  40.1%   # still hot — largest group
+  SourceData        7.37 MB  21.9%   # cold
+  Person            2.78 MB   8.3%   # Name/AltNames cold; IDs/titles/dates hot
+  Business          2.78 MB   8.3%
+  Contact           1.99 MB   5.9%   # phones/faxes/websites cold; emails hot
+  Addresses         1.93 MB   5.8%   # raw cold; PreparedFields.Addresses hot
+  Name+IDs          1.82 MB   5.4%
+  Affiliations      0.80 MB   2.4%   # Details cold
+  SanctionsInfo     0.31 MB   0.9%   # Description cold
+  Vessel/Aircraft/Crypto/… remainder
+
+## Size report (TestCorpus_MemoryReport)
+entities=16989
+full_gob_MB=12.34
+full_B_per_entity=762
+hot_gob_MB=5.63          # was 7.60 with SourceData-only cold
+hot_B_per_entity=348     # was 469
+cold_payload_MB=12.79    # expanded cold fields
+snapshot_file_MB=13.05   # gob+zstd on disk
+cold_stripped_share=54.4%  # was 38.4% with SourceData-only
+
+## Latency / allocs (BenchmarkCorpus_, count=1)
+BenchmarkCorpus_Baseline_Similarity        ~1.47 ms/op   score path unchanged
+BenchmarkCorpus_Tiered_Similarity          ~1.48 ms/op
+BenchmarkCorpus_Tiered_HydrateTopN         ~0.43 ms/op   top-20 cold hydrate (zstd)
+BenchmarkCorpus_Baseline_BuildCorpus       ~15 ms/op
+BenchmarkCorpus_Tiered_BuildCorpus        ~337 ms/op   snapshot write + cold encode
+BenchmarkCorpus_Baseline_SelectAndScore    ~165 µs/op    108 candidates
+BenchmarkCorpus_Tiered_SelectAndScore      ~164 µs/op
+
+## Takeaways
+- Deeper cold split cuts hot gob ~54% vs full (5.63 vs 12.34 MB proxy).
+- PreparedFields is the next mountain (~40% of field breakdown) — needs denser
+  encoding / string table, not just "move to disk" (it is on the score path).
+- Score path stays flat; hydrate top-20 stays sub-ms.
+- Refresh cost is the tradeoff until binary hot table + parallel encode.
+
+## Live profiles (production)
+Admin server (default :9094) already exposes pprof. New endpoint:
+  GET /debug/memory?gc=1
+Collect bundle:
+  ./internal/corpusfile/collect_profiles.sh http://127.0.0.1:9094 ./profiles
+EOF

--- a/internal/index/admin_memory.go
+++ b/internal/index/admin_memory.go
@@ -1,0 +1,112 @@
+package index
+
+import (
+	"encoding/json"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/moov-io/base/admin"
+)
+
+// MemoryReport is exposed on the admin server for live RSS / corpus sizing.
+// Pair with pprof heap profiles from the same admin port for allocation detail.
+type MemoryReport struct {
+	Time    time.Time `json:"time"`
+	Version string    `json:"version,omitempty"`
+
+	// Process memory (Go runtime)
+	HeapAlloc  uint64 `json:"heapAlloc"`
+	HeapSys    uint64 `json:"heapSys"`
+	HeapInuse  uint64 `json:"heapInuse"`
+	HeapIdle   uint64 `json:"heapIdle"`
+	StackInuse uint64 `json:"stackInuse"`
+	Sys        uint64 `json:"sys"`
+	NumGC      uint32 `json:"numGC"`
+	GCCPUFraction float64 `json:"gcCPUFraction"`
+
+	// Corpus summary from the last successful refresh
+	EntityCount int            `json:"entityCount"`
+	Lists       map[string]int `json:"lists,omitempty"`
+	RefreshStartedAt time.Time `json:"refreshStartedAt,omitempty"`
+	RefreshEndedAt   time.Time `json:"refreshEndedAt,omitempty"`
+
+	// How to pull deeper profiles from this admin server
+	PprofHints PprofHints `json:"pprofHints"`
+}
+
+// PprofHints documents the always-on admin pprof routes (moov-io/base/admin).
+type PprofHints struct {
+	Heap      string `json:"heap"`
+	Allocs    string `json:"allocs"`
+	Goroutine string `json:"goroutine"`
+	Profile   string `json:"cpuProfile"`
+	Note      string `json:"note"`
+}
+
+// RegisterMemoryAdmin adds GET /debug/memory with live MemStats + corpus counts.
+func RegisterMemoryAdmin(svc *admin.Server, lists Lists) {
+	if svc == nil || lists == nil {
+		return
+	}
+	svc.AddHandler("/debug/memory", memoryHandler(lists))
+}
+
+func memoryHandler(lists Lists) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Optional GC so heap numbers are less noisy when debugging.
+		if r.URL.Query().Get("gc") == "1" {
+			runtime.GC()
+		}
+
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		stats := lists.LatestStats()
+
+		// Prefer corpus length when built; fall back to summing list counts.
+		entityCount := 0
+		if n := EntityCount(lists); n > 0 {
+			entityCount = n
+		} else {
+			for _, n := range stats.Lists {
+				entityCount += n
+			}
+		}
+
+		report := MemoryReport{
+			Time:    time.Now().UTC(),
+			Version: stats.Version,
+			HeapAlloc:     ms.HeapAlloc,
+			HeapSys:       ms.HeapSys,
+			HeapInuse:     ms.HeapInuse,
+			HeapIdle:      ms.HeapIdle,
+			StackInuse:    ms.StackInuse,
+			Sys:           ms.Sys,
+			NumGC:         ms.NumGC,
+			GCCPUFraction: ms.GCCPUFraction,
+			EntityCount:   entityCount,
+			Lists:         stats.Lists,
+			RefreshStartedAt: stats.StartedAt,
+			RefreshEndedAt:   stats.EndedAt,
+			PprofHints: PprofHints{
+				Heap:      "/debug/pprof/heap",
+				Allocs:    "/debug/pprof/allocs",
+				Goroutine: "/debug/pprof/goroutine",
+				Profile:   "/debug/pprof/profile?seconds=30",
+				Note: "curl -o heap.pb.gz http://ADMIN/debug/pprof/heap && go tool pprof -http=:8081 heap.pb.gz. " +
+					"Most useful: inuse_space after a refresh settles; alloc_space for refresh cost. " +
+					"Also GET /debug/memory?gc=1 for a post-GC snapshot.",
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(report)
+	}
+}

--- a/internal/index/admin_memory_test.go
+++ b/internal/index/admin_memory_test.go
@@ -1,0 +1,53 @@
+package index
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryHandler(t *testing.T) {
+	lists := NewLists(nil)
+	lists.Update(download.Stats{
+		Entities: []search.Entity[search.Value]{
+			{Name: "A", Type: search.EntityPerson, Source: search.SourceUSOFAC, SourceID: "1"},
+			{Name: "B", Type: search.EntityBusiness, Source: search.SourceUSOFAC, SourceID: "2"},
+		},
+		Lists:     map[string]int{string(search.SourceUSOFAC): 2},
+		StartedAt: time.Now().Add(-time.Minute),
+		EndedAt:   time.Now(),
+		Version:   "test",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/memory", nil)
+	rr := httptest.NewRecorder()
+	memoryHandler(lists)(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+
+	var report MemoryReport
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &report))
+	require.Equal(t, 2, report.EntityCount)
+	require.Equal(t, map[string]int{string(search.SourceUSOFAC): 2}, report.Lists)
+	require.NotEmpty(t, report.PprofHints.Heap)
+	require.Greater(t, report.Sys, uint64(0))
+}
+
+func TestEntityCount(t *testing.T) {
+	lists := NewLists(nil)
+	require.Equal(t, 0, EntityCount(lists))
+
+	lists.Update(download.Stats{
+		Entities: []search.Entity[search.Value]{{Name: "x", Source: search.SourceUSOFAC}},
+		Lists:    map[string]int{string(search.SourceUSOFAC): 1},
+	})
+	require.Equal(t, 1, EntityCount(lists))
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -132,3 +132,17 @@ func (l *lists) GetTFIDFIndex() *tfidf.Index {
 	}
 	return l.latestStats.TFIDFIndex
 }
+
+// EntityCount returns the number of entities in the in-memory corpus, or 0.
+func EntityCount(l Lists) int {
+	impl, ok := l.(*lists)
+	if !ok || impl == nil {
+		return 0
+	}
+	impl.mu.RLock()
+	defer impl.mu.RUnlock()
+	if impl.corpus == nil {
+		return 0
+	}
+	return len(impl.corpus.entities)
+}

--- a/pkg/search/similarity.go
+++ b/pkg/search/similarity.go
@@ -561,10 +561,11 @@ func countCommonFields[I any](index Entity[I]) int {
 	if len(index.Contact.EmailAddresses) > 0 {
 		count++
 	}
-	if len(index.Contact.PhoneNumbers) > 0 {
+	// Phones/faxes may only exist on PreparedFields when raw Contact is cold-stripped.
+	if len(index.Contact.PhoneNumbers) > 0 || len(index.PreparedFields.Contact.PhoneNumbers) > 0 {
 		count++
 	}
-	if len(index.Contact.FaxNumbers) > 0 {
+	if len(index.Contact.FaxNumbers) > 0 || len(index.PreparedFields.Contact.FaxNumbers) > 0 {
 		count++
 	}
 	if len(index.CryptoAddresses) > 0 {
@@ -573,7 +574,7 @@ func countCommonFields[I any](index Entity[I]) int {
 	if len(index.Affiliations) > 0 {
 		count++
 	}
-	if len(index.Addresses) > 0 {
+	if len(index.Addresses) > 0 || len(index.PreparedFields.Addresses) > 0 {
 		count++
 	}
 

--- a/pkg/search/similarity_address.go
+++ b/pkg/search/similarity_address.go
@@ -21,15 +21,17 @@ func compareAddresses[Q any, I any](w io.Writer, query Entity[Q], index Entity[I
 	fieldsCompared := 0
 	var scores []float64
 
+	qAddrs := query.PreparedFields.Addresses
+	iAddrs := index.PreparedFields.Addresses
 	if w != nil {
-		debug(w, "address comparison details: query=%d  index=%d\n", len(query.Addresses), len(index.Addresses))
+		debug(w, "address comparison details: query=%d  index=%d\n", len(qAddrs), len(iAddrs))
 	}
 
-	// Compare addresses
-	if len(query.Addresses) > 0 && len(index.Addresses) > 0 {
+	// Score prepared addresses only — raw Addresses may live in cold storage.
+	if len(qAddrs) > 0 && len(iAddrs) > 0 {
 		fieldsCompared++
 
-		if score := findBestAddressMatch(w, query.PreparedFields.Addresses, index.PreparedFields.Addresses); score > 0 {
+		if score := findBestAddressMatch(w, qAddrs, iAddrs); score > 0 {
 			scores = append(scores, score)
 		}
 	}


### PR DESCRIPTION
## Summary

Experimental work exploring a smaller in-memory search working set:

- `internal/corpusfile`: hot/cold entity split, snapshot layout sketch, gob+zstd cold blobs, size/field breakdown benches
- Admin `GET /debug/memory` for live MemStats + corpus counts (pprof already on admin)
- Search similarity gates use `PreparedFields.Addresses` so raw addresses are not required on the score path

**Not production-ready** and not wired into `index.Lists` search. Opened for the record; intended to be closed without merge unless we pick this up later.

## Test plan

- [x] `go test ./internal/corpusfile/ ./internal/index/ ./pkg/search/ ./cmd/server/`
- [x] `go test ./internal/corpusfile/ -bench=BenchmarkCorpus_ -benchmem` (local baseline in package testdata)