### PR TITLE
fix: reduce refresh memory peak after corpus swap

### DIFF
--- a/internal/download/refresh.go
+++ b/internal/download/refresh.go
@@ -153,17 +153,26 @@ func (r *Refresher) run(ctx context.Context) error {
 		return err
 	}
 
+	entityCount := len(stats.Entities)
 	r.logger.Info().Logf("data refreshed - %v entities from %v lists took %v (using %.2fGB)",
-		len(stats.Entities), len(stats.Lists), stats.EndedAt.Sub(stats.StartedAt), getCurrentMemoryUsed())
+		entityCount, len(stats.Lists), stats.EndedAt.Sub(stats.StartedAt), getCurrentMemoryUsed())
 
 	if r.indexedLists != nil {
+		// Index takes ownership of the entity slice inside the corpus. Clear our
+		// local roots afterward so RefreshAll's return value does not keep the
+		// previous generation + new slice alive on this stack until run returns.
 		r.indexedLists.Update(stats)
+		stats.Entities = nil
+		stats.TFIDFIndex = nil
 	}
 	if r.searchService != nil {
+		// Rebuild reads entities from the live index (corpus), not stats.Entities.
 		if err := r.searchService.RebuildEmbeddingIndex(ctx); err != nil {
 			return fmt.Errorf("failed to rebuild embedding index: %w", err)
 		}
 	}
+
+	r.logger.Info().Logf("search index swapped (%d entities, heap %.2fGB)", entityCount, getCurrentMemoryUsed())
 	return nil
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -3,6 +3,8 @@ package index
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"runtime/debug"
 	"sync"
 
 	"github.com/moov-io/watchman"
@@ -112,15 +114,44 @@ func (l *lists) LatestStats() download.Stats {
 	return out
 }
 
+// Update replaces the searchable corpus with a newly downloaded generation.
+//
+// Memory ownership after Update:
+//   - The entity slice and TF-IDF index live only on the in-memory corpus.
+//   - latestStats keeps list metadata (counts, hashes, timestamps) only.
+//
+// Callers should drop their own references to stats.Entities after Update so the
+// previous generation (and download temps) can be collected. Update runs a GC
+// and FreeOSMemory after the swap to reduce refresh peak RSS / OOM risk when the
+// old and new corpora would otherwise coexist until the next natural GC cycle.
 func (l *lists) Update(latest download.Stats) {
-	// Build search corpus outside the write lock (CPU-heavy)
+	// Build search corpus outside the write lock (CPU-heavy).
+	// corpus.entities aliases latest.Entities (no extra copy of the slice).
 	c := buildCorpus(latest.Entities, latest.TFIDFIndex)
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
+	// Metadata only — do not retain a second root to the entity slice / TF-IDF
+	// via latestStats (LatestStats() already omitted Entities; this makes the
+	// in-process graph match that intent).
+	meta := latest
+	meta.Entities = nil
+	meta.TFIDFIndex = nil
 
-	l.latestStats = latest
+	l.mu.Lock()
+	prev := l.corpus
+	l.latestStats = meta
 	l.corpus = c
+	l.mu.Unlock()
+
+	// Previous corpus is unreachable from lists after unlock. Clear the local
+	// ref so this frame does not keep it alive across GC below.
+	prev = nil
+	_ = prev
+
+	// Refresh is infrequent; reclaim the prior generation promptly so cgroup
+	// peaks are closer to one corpus than two. FreeOSMemory returns idle heap
+	// pages to the OS (important after large refreshes).
+	runtime.GC()
+	debug.FreeOSMemory()
 }
 
 func (l *lists) GetTFIDFIndex() *tfidf.Index {

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -137,15 +137,11 @@ func (l *lists) Update(latest download.Stats) {
 	meta.TFIDFIndex = nil
 
 	l.mu.Lock()
-	prev := l.corpus
+	// Overwriting l.corpus drops the only lists-owned root to the previous
+	// generation; nothing else in this frame retains it.
 	l.latestStats = meta
 	l.corpus = c
 	l.mu.Unlock()
-
-	// Previous corpus is unreachable from lists after unlock. Clear the local
-	// ref so this frame does not keep it alive across GC below.
-	prev = nil
-	_ = prev
 
 	// Refresh is infrequent; reclaim the prior generation promptly so cgroup
 	// peaks are closer to one corpus than two. FreeOSMemory returns idle heap

--- a/internal/index/update_test.go
+++ b/internal/index/update_test.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/moov-io/watchman/internal/download"
+	"github.com/moov-io/watchman/pkg/search"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLists_Update_CorpusOwnsEntities(t *testing.T) {
+	lists := NewLists(nil).(*lists)
+
+	gen := func(tag string, n int) []search.Entity[search.Value] {
+		out := make([]search.Entity[search.Value], n)
+		for i := range out {
+			out[i] = search.Entity[search.Value]{
+				Name:     fmt.Sprintf("%s-%d", tag, i),
+				Type:     search.EntityPerson,
+				Source:   search.SourceUSOFAC,
+				SourceID: fmt.Sprintf("%s-%d", tag, i),
+			}.Normalize()
+		}
+		return out
+	}
+
+	first := gen("first", 50)
+	lists.Update(download.Stats{
+		Entities: first,
+		Lists:    map[string]int{string(search.SourceUSOFAC): len(first)},
+	})
+
+	// Metadata must not hold a second root to the entity slice.
+	require.Nil(t, lists.latestStats.Entities)
+	require.Nil(t, lists.latestStats.TFIDFIndex)
+	require.NotNil(t, lists.corpus)
+	require.Len(t, lists.corpus.entities, 50)
+
+	got, err := lists.GetEntities(context.Background(), search.SourceUSOFAC)
+	require.NoError(t, err)
+	require.Len(t, got, 50)
+	require.Equal(t, "first-0", got[0].SourceID)
+
+	// Second generation replaces the first; search still works.
+	second := gen("second", 30)
+	lists.Update(download.Stats{
+		Entities: second,
+		Lists:    map[string]int{string(search.SourceUSOFAC): len(second)},
+	})
+	require.Nil(t, lists.latestStats.Entities)
+	require.Len(t, lists.corpus.entities, 30)
+
+	got, err = lists.GetEntities(context.Background(), search.SourceUSOFAC)
+	require.NoError(t, err)
+	require.Len(t, got, 30)
+	require.Equal(t, "second-0", got[0].SourceID)
+
+	// Candidate selection uses the new corpus only.
+	cands, err := lists.SelectCandidates(context.Background(), search.Entity[search.Value]{
+		Name:   "second-1",
+		Type:   search.EntityPerson,
+		Source: search.SourceUSOFAC,
+	}.Normalize())
+	require.NoError(t, err)
+	require.NotEmpty(t, cands)
+
+	stats := lists.LatestStats()
+	require.Nil(t, stats.Entities)
+	require.Equal(t, 30, stats.Lists[string(search.SourceUSOFAC)])
+}
+
+func TestLists_Update_Empty(t *testing.T) {
+	lists := NewLists(nil)
+	lists.Update(download.Stats{
+		Lists: map[string]int{},
+	})
+	got, err := lists.GetEntities(context.Background(), "")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}


### PR DESCRIPTION
## Summary

Reduces Go-heap peak / OOM risk during list refresh (the ~2× window when old and new corpora coexist):

1. **`index.Lists.Update`** — after building the new corpus, store only metadata on `latestStats` (`Entities` / `TFIDFIndex` nil). The searchable slice lives solely on the corpus (same as what `LatestStats()` already exposed). Swap under lock, then `runtime.GC()` + `debug.FreeOSMemory()` so the previous generation is reclaimed promptly rather than waiting for a later GC cycle.

2. **`download.Refresher`** — after a successful `Update`, clear local `stats.Entities` / `TFIDFIndex` so the refresh stack does not pin the new slice until `run` returns. Log heap after the swap. Embedding rebuild still reads from the live index via `GetEntities`.

Does not change search results or refresh semantics. Does not address libpostal/RSS; this is the in-process Go corpus double-buffer.

## Test plan

- [x] `go test ./internal/index/ -run TestLists_Update`
- [x] `go test ./internal/download/ -run TestRefresher`
- [ ] Manual: watch `go_memstats_heap_alloc_bytes` / RSS across a forced refresh on a multi-list deploy