### PR TITLE
fix: resolve open CodeQL findings on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - name: Create Release
       id: create_release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         tag_name: ${{ github.ref_name }}
         name: Release ${{ github.ref_name }}
@@ -179,7 +179,7 @@ jobs:
 
     - name: Login to Docker Hub
       if: ${{ env.DOCKER_USERNAME }} != ""
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -208,7 +208,7 @@ jobs:
 
     - name: Login to Docker Hub
       if: ${{ env.DOCKER_USERNAME }} != ""
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
@@ -283,7 +283,7 @@ jobs:
 
     - name: Login to Docker Hub
       if: ${{ env.DOCKER_USERNAME }} != ""
-      uses: docker/login-action@v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/internal/ingest/api_ingest.go
+++ b/internal/ingest/api_ingest.go
@@ -71,17 +71,19 @@ func (c *controller) ingestFile(w http.ResponseWriter, r *http.Request) {
 
 	parsedFile, err := c.service.ReadEntitiesFromFile(ctx, fileType, r.Body)
 	if err != nil {
-		err = logger.Error().LogErrorf("problem reading entities from %s file: %v", fileType, err).Err()
+		// file_type is already attached as a structured field; avoid interpolating
+		// user-controlled values into the log message (CWE-117 / go/log-injection).
+		err = logger.Error().LogErrorf("problem reading entities from file: %v", err).Err()
 		api.ErrorResponse(w, err)
 		return
 	}
 
-	logger.Info().Logf("found %d entities from %s file", len(parsedFile.Entities), parsedFile.FileType)
+	logger.Info().Logf("found %d entities from file", len(parsedFile.Entities))
 
 	// Save the parsed entities
 	err = c.service.ReplaceEntities(ctx, parsedFile.FileType, parsedFile.Entities)
 	if err != nil {
-		err = logger.Error().LogErrorf("problem updating %s entities: %v", fileType, err).Err()
+		err = logger.Error().LogErrorf("problem updating entities: %v", err).Err()
 		api.ErrorResponse(w, err)
 		return
 	}


### PR DESCRIPTION
## Summary
- Fix CodeQL `go/log-injection` errors in ingest API by not interpolating user-controlled `fileType` into log message text (value remains on the structured `file_type` field).
- Pin third-party Actions in `release.yml` (`softprops/action-gh-release`, `docker/login-action`) by commit SHA to clear `actions/unpinned-tag` warnings.

## Alerts addressed
- https://github.com/moov-io/watchman/security/code-scanning/50
- https://github.com/moov-io/watchman/security/code-scanning/52
- https://github.com/moov-io/watchman/security/code-scanning/61
- https://github.com/moov-io/watchman/security/code-scanning/62
- https://github.com/moov-io/watchman/security/code-scanning/63
- https://github.com/moov-io/watchman/security/code-scanning/64

## Test plan
- [x] `gofmt` applied
- [x] package compiles (`go test -c ./internal/ingest/`)
- [ ] CI CodeQL + Go tests on this PR