### PR TITLE
fix(ci): clear release workflow deprecation warnings

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -93,16 +93,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
 
     - name: Short Tests
       run: go test ./pkg/sources... -count 1 -v
@@ -114,16 +114,16 @@ jobs:
       matrix:
         os: [macos-latest]
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
 
     - name: Install Libpostal
       run: make install
@@ -151,14 +151,14 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Docker Hub
       run: make docker-hub
@@ -178,14 +178,14 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Docker Hub
       run: make docker-openshift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,26 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # For creating release
-      actions: write   # For uploading artifact
     steps:
     - name: Create Release
-      id: create_release
       uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         tag_name: ${{ github.ref_name }}
         name: Release ${{ github.ref_name }}
         prerelease: true
         token: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Output Release URL File
-      run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
-
-    - name: Save Release URL File for publish
-      uses: actions/upload-artifact@v7
-      with:
-        name: release_url
-        path: release_url.txt
-        retention-days: 1
 
   publish:
     name: Publish
@@ -60,22 +48,15 @@ jobs:
             arch: amd64
     permissions:
       contents: write  # For uploading release assets
-      actions: read    # For downloading artifact
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
-
-    - name: Load Release URL File from release job
-      uses: actions/download-artifact@v8
-      with:
-        name: release_url
-        path: release_url
 
     - name: Setup Linux Dependencies
       if: runner.os == 'Linux'
@@ -96,48 +77,23 @@ jobs:
       env:
         ARCH: ${{ matrix.arch }}
 
-    - name: Get Release File Name & Upload URL
-      id: get_release_info
-      shell: bash
-      run: |
-        value=`cat release_url/release_url.txt`
-        echo ::set-output name=upload_url::$value
-      env:
-        TAG_REF_NAME: ${{ github.ref }}
-        REPOSITORY_NAME: ${{ github.repository }}
-
     - name: Upload Linux Binary
       if: runner.os == 'Linux'
-      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/watchman-linux-${{ matrix.arch }}
-        asset_name: watchman-linux-${{ matrix.arch }}
-        asset_content_type: application/octet-stream
+      run: gh release upload "${{ github.ref_name }}" "./bin/watchman-linux-${{ matrix.arch }}" --clobber
 
     - name: Upload macOS Binary
       if: runner.os == 'macOS'
-      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/watchman-darwin-${{ matrix.arch }}
-        asset_name: watchman-darwin-${{ matrix.arch }}
-        asset_content_type: application/octet-stream
+      run: gh release upload "${{ github.ref_name }}" "./bin/watchman-darwin-${{ matrix.arch }}" --clobber
 
     - name: Upload Windows Binary
       if: runner.os == 'Windows'
-      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release_info.outputs.upload_url }}
-        asset_path: ./bin/watchman.exe
-        asset_name: watchman.exe
-        asset_content_type: application/octet-stream
+      run: gh release upload "${{ github.ref_name }}" "./bin/watchman.exe" --clobber
 
   docker-hub:
     name: Docker Hub (${{ matrix.platform }})
@@ -155,14 +111,14 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Clean
       run: make clean
@@ -197,14 +153,14 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Login to Docker Hub
       if: ${{ env.DOCKER_USERNAME }} != ""
@@ -233,14 +189,14 @@ jobs:
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Clean
       run: make clean
@@ -272,14 +228,14 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
         go-version: stable
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v7
 
     - name: Login to Docker Hub
       if: ${{ env.DOCKER_USERNAME }} != ""


### PR DESCRIPTION
## Summary
- Replace deprecated `actions/upload-release-asset@v1` (Node 20) and `::set-output` with `gh release upload`, dropping the release URL artifact handoff
- Run `actions/checkout` before `actions/setup-go` in release and go workflows so Go module caching can find `go.mod`

Fixes warnings from https://github.com/moov-io/watchman/actions/runs/31540554615:
- Node.js 20 deprecation from `actions/upload-release-asset@v1`
- `set-output` deprecation
- Restore cache failed: `go.mod` not found

## Test plan
- [ ] CI passes on this PR (go workflow step order)
- [ ] Next tagged release publishes binaries without the three annotation warnings above