### PR TITLE
ci: stabilize TestMinMaxMed and benchmark failure logs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Log Failure
       if: ${{ failure() }}
-      run: cat ./output.txt
+      run: cat ./output.txt || true
 
     - name: Store benchmark result
       if: steps.should_run_benchmarks.outputs.should_run == 'true'
@@ -84,7 +84,7 @@ jobs:
 
     - name: Log Failure
       if: ${{ failure() }}
-      run: cat ./output.txt
+      run: cat ./output.txt || true
 
     - name: Store OFAC results
       if: steps.should_run_benchmarks.outputs.should_run == 'true'
@@ -113,7 +113,7 @@ jobs:
 
     - name: Log Failure
       if: ${{ failure() }}
-      run: cat ./output.txt
+      run: cat ./output.txt || true
 
     - name: Store CSL US results
       if: steps.should_run_benchmarks.outputs.should_run == 'true'

--- a/internal/minmaxmed/minmaxmed_test.go
+++ b/internal/minmaxmed/minmaxmed_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"runtime"
 	"testing"
 	"time"
 
@@ -87,10 +86,6 @@ func TestMinMaxMed(t *testing.T) {
 	})
 
 	t.Run("time", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("time is wonky on Windows")
-		}
-
 		ctx := context.Background()
 
 		var buf bytes.Buffer
@@ -101,15 +96,12 @@ func TestMinMaxMed(t *testing.T) {
 
 		_, span := telemetry.StartSpan(ctx, "minmaxmed-scores")
 
+		// Use fixed durations so stats do not depend on wall-clock sleep,
+		// which overshoots enough on macOS/Windows CI to fail tight deltas.
 		m := minmaxmed.New(5)
-		start := time.Now()
-
-		time.Sleep(10 * time.Millisecond)
-		m.AddDuration(time.Since(start))
-		time.Sleep(20 * time.Millisecond)
-		m.AddDuration(time.Since(start))
-		time.Sleep(30 * time.Millisecond)
-		m.AddDuration(time.Since(start))
+		m.AddDuration(10 * time.Millisecond)
+		m.AddDuration(30 * time.Millisecond)
+		m.AddDuration(60 * time.Millisecond)
 
 		m.AddEvent(span)
 		span.End()
@@ -125,19 +117,19 @@ func TestMinMaxMed(t *testing.T) {
 		for i := range evt.Attributes {
 			switch evt.Attributes[i].Key {
 			case "min_ms":
-				require.Greater(t, evt.Attributes[i].Value.Value, 0.0)
+				require.Equal(t, int64(10), int64(evt.Attributes[i].Value.Value))
 				require.Equal(t, "INT64", evt.Attributes[i].Value.Type)
 
 			case "max_ms":
-				require.Greater(t, evt.Attributes[i].Value.Value, 50.0)
+				require.Equal(t, int64(60), int64(evt.Attributes[i].Value.Value))
 				require.Equal(t, "INT64", evt.Attributes[i].Value.Type)
 
 			case "median_ms":
-				require.InDelta(t, 30.0, evt.Attributes[i].Value.Value, 10.0)
+				require.InDelta(t, 30.0, evt.Attributes[i].Value.Value, 0.01)
 				require.Equal(t, "FLOAT64", evt.Attributes[i].Value.Type)
 
 			case "average_ms":
-				require.InDelta(t, 30.0, evt.Attributes[i].Value.Value, 10.0)
+				require.InDelta(t, 100.0/3.0, evt.Attributes[i].Value.Value, 0.01)
 				require.Equal(t, "FLOAT64", evt.Attributes[i].Value.Type)
 
 			case "observations":


### PR DESCRIPTION
## Summary

Master Go CI failed on `Short tests (macos-latest)` in [run 33667224074](https://github.com/moov-io/watchman/actions/runs/33667224074):

```
--- FAIL: TestMinMaxMed/time
    Error: Max difference between 30 and 49 allowed is 10, but difference was -19
```

`TestMinMaxMed/time` slept on the wall clock and asserted median ≈ 30ms ± 10ms. macOS runners overshot those sleeps (Windows already skipped the test for the same reason). The test now records known `AddDuration` values so stats are deterministic.

The scheduled Benchmarks workflow also failed in [run 33655025632](https://github.com/moov-io/watchman/actions/runs/33655025632) with a transient DNS error in `setup-go` (`getaddrinfo EAI_AGAIN raw.githubusercontent.com`). The follow-on `Log Failure` steps then failed because `output.txt` did not exist. Those steps now tolerate a missing file.

## Test plan

- [x] `go test ./internal/minmaxmed/ -count=5 -run 'TestMinMaxMed$'`
- [ ] CI: Short tests on macos-latest, ubuntu-latest, windows-latest