### PR TITLE
fix(deps): update module github.com/openrouterteam/go-sdk to v0.7.108

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.27.1
 
 require (
 	fyne.io/fyne/v2 v2.8.1
-	github.com/OpenRouterTeam/go-sdk v0.7.106
+	github.com/OpenRouterTeam/go-sdk v0.7.108
 	github.com/abadojack/whatlanggo v1.0.1
 	github.com/adamdecaf/merge v0.2.2
 	github.com/antchfx/htmlquery v1.3.6

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0/go.mod h1:6ZZMQhZKDvUvkJw2rc+oDP90tMMzuU/J+5HG1ZmPOmE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/OpenRouterTeam/go-sdk v0.7.106 h1:2Q6kzJnd4Zj2W14C8T9hCb+FcxcAQ/HB4WUfG0Qx0JY=
-github.com/OpenRouterTeam/go-sdk v0.7.106/go.mod h1:8vFtUZ9I2YiDntYbck42wQhrx9DsJN5PHbViaHwTkXc=
+github.com/OpenRouterTeam/go-sdk v0.7.108 h1:wEdUcYHtPVkdLvba9Tmsq8JhboferkJZVEzFh0NyJ5Y=
+github.com/OpenRouterTeam/go-sdk v0.7.108/go.mod h1:8vFtUZ9I2YiDntYbck42wQhrx9DsJN5PHbViaHwTkXc=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=


### PR DESCRIPTION
## Summary

Bump `github.com/OpenRouterTeam/go-sdk` from v0.7.106 to v0.7.108. This is the only outdated direct Go module.

Renovate has not opened this yet (dashboard lookup warnings on a few packages). `renovate.json` already automerges minor/patch updates.

## Test plan

- [x] `go test ./internal/embeddings/ -count=1 -short`
- [ ] CI green, then automerge