### PR TITLE
download: read ERROR_ON_EMPTY_LIST from environment

### DIFF
--- a/internal/download/config.go
+++ b/internal/download/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	//
 	// Setting this to true enables early detection of potential data integrity problems.
 	// Default: false
+	//
+	// Use the ERROR_ON_EMPTY_LIST environment variable to set this at runtime.
 	ErrorOnEmptyList bool
 
 	IncludedLists []search.SourceList // us_ofac, eu_csl, etc...

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/moov-io/base/log"
+	"github.com/moov-io/base/strx"
 	"github.com/moov-io/base/telemetry"
 	"github.com/moov-io/watchman/internal/tfidf"
 	"github.com/moov-io/watchman/pkg/search"
@@ -539,6 +540,16 @@ func expandInitialDir(initialDir string) string {
 
 func initialDataDirectory(conf Config) string {
 	return cmp.Or(os.Getenv("INITIAL_DATA_DIRECTORY"), conf.InitialDataDirectory)
+}
+
+// errorOnEmptyList reports whether an empty list should fail the refresh.
+// The ERROR_ON_EMPTY_LIST environment variable takes precedence over the
+// YAML-configured ErrorOnEmptyList field when it is set.
+func errorOnEmptyList(conf Config) bool {
+	if fromEnvStr := strings.TrimSpace(os.Getenv("ERROR_ON_EMPTY_LIST")); fromEnvStr != "" {
+		return strx.Yes(fromEnvStr)
+	}
+	return conf.ErrorOnEmptyList
 }
 
 // geocodeEntities applies geocoding to all addresses in the given entities.

--- a/internal/download/download_eu.go
+++ b/internal/download/download_eu.go
@@ -76,7 +76,7 @@ func loadEUCSLRecords(ctx context.Context, logger log.Logger, conf Config, respo
 	logger.Debug().Logf("finished EU CSL preparation: %d entities in %v", len(entities), time.Since(start))
 	span.AddEvent("finished EU CSL preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from EU CSL")
 	}
 

--- a/internal/download/download_fincen311.go
+++ b/internal/download/download_fincen311.go
@@ -46,7 +46,7 @@ func loadFinCEN311Records(ctx context.Context, logger log.Logger, conf Config, r
 	logger.Debug().Logf("finished FinCEN 311 preparation: %v", time.Since(start))
 	span.AddEvent("finished FinCEN 311 preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from FinCEN 311")
 	}
 

--- a/internal/download/download_private_test.go
+++ b/internal/download/download_private_test.go
@@ -132,6 +132,83 @@ func TestConfig_getIncludedLists(t *testing.T) {
 	}
 }
 
+func TestConfig_errorOnEmptyList(t *testing.T) {
+	cases := []struct {
+		name     string
+		conf     Config
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "empty config and env",
+			conf:     Config{},
+			expected: false,
+		},
+		{
+			name:     "from config field only",
+			conf:     Config{ErrorOnEmptyList: true},
+			expected: true,
+		},
+		{
+			name:     "from env var only",
+			conf:     Config{},
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var yes",
+			conf:     Config{},
+			envValue: "yes",
+			expected: true,
+		},
+		{
+			name:     "env var with whitespace",
+			conf:     Config{},
+			envValue: " TRUE ",
+			expected: true,
+		},
+		{
+			name:     "env var and config field both true",
+			conf:     Config{ErrorOnEmptyList: true},
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var and config field both false",
+			conf:     Config{},
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "env var overrides config field",
+			conf:     Config{ErrorOnEmptyList: true},
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "blank env var keeps config field",
+			conf:     Config{ErrorOnEmptyList: true},
+			envValue: "  ",
+			expected: true,
+		},
+		{
+			name:     "unparsable env var is false",
+			conf:     Config{},
+			envValue: "maybe",
+			expected: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envValue != "" {
+				t.Setenv("ERROR_ON_EMPTY_LIST", tc.envValue)
+			}
+			got := errorOnEmptyList(tc.conf)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 func TestConfig_findExtraLists(t *testing.T) {
 	cases := []struct {
 		name           string

--- a/internal/download/download_senzing.go
+++ b/internal/download/download_senzing.go
@@ -98,7 +98,7 @@ func processSenzingList(ctx context.Context, logger log.Logger, dl *download.Dow
 		return fmt.Errorf("parsing %s failed: %w", source, err)
 	}
 
-	if len(entities) == 0 && params.config.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(params.config) {
 		if ignored {
 			logger.Warn().Logf("ignoring empty list for %s", source)
 			return nil

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -249,6 +249,36 @@ func TestDownloader_RefreshAll_DoesNotIgnoreUnconfiguredEmptySenzingList(t *test
 	require.Error(t, err, "empty list error for non-ignored list must propagate")
 }
 
+// TestDownloader_RefreshAll_ErrorOnEmptyListFromEnv verifies that the
+// ERROR_ON_EMPTY_LIST environment variable enables the empty-list check
+// without the ErrorOnEmptyList config field being set.
+func TestDownloader_RefreshAll_ErrorOnEmptyListFromEnv(t *testing.T) {
+	logger := log.NewTestLogger()
+	emptyFile := emptySenzingFile(t)
+
+	const listName search.SourceList = "senzing-empty-env"
+
+	conf := download.Config{
+		// ErrorOnEmptyList intentionally left false
+		Senzing: []download.SenzingList{
+			{SourceList: listName, Location: "file://" + emptyFile},
+		},
+	}
+	dl, err := download.NewDownloader(logger, conf, nil)
+	require.NoError(t, err)
+
+	// Without the env var an empty list is tolerated.
+	stats, err := dl.RefreshAll(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, stats.Lists[string(listName)])
+
+	// With the env var the empty list is an error.
+	t.Setenv("ERROR_ON_EMPTY_LIST", "true")
+
+	_, err = dl.RefreshAll(context.Background())
+	require.ErrorContains(t, err, "no entities parsed from senzing list")
+}
+
 // TestDownloader_RefreshAll_IgnoredDownloadError_CustomListCasing validates that
 // a custom (Senzing) list name declared with unusual casing/whitespace can still
 // be successfully referenced in IgnoredDownloadErrors using different casing.

--- a/internal/download/download_uk.go
+++ b/internal/download/download_uk.go
@@ -76,7 +76,7 @@ func loadUKCSLRecords(ctx context.Context, logger log.Logger, conf Config, respo
 	logger.Debug().Logf("finished UK CSL preparation: %d entities in %v", len(entities), time.Since(start))
 	span.AddEvent("finished UK CSL preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from UK CSL")
 	}
 

--- a/internal/download/download_un.go
+++ b/internal/download/download_un.go
@@ -79,7 +79,7 @@ func loadUNCSLRecords(ctx context.Context, logger log.Logger, conf Config, respo
 
 	logger.Debug().Logf("finished UN CSL preparation: %d entities in %v", len(entities), time.Since(start))
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from UN list")
 	}
 

--- a/internal/download/download_us.go
+++ b/internal/download/download_us.go
@@ -46,7 +46,7 @@ func loadOFACRecords(ctx context.Context, logger log.Logger, conf Config, respon
 	logger.Debug().Logf("finished OFAC preparation: %v", time.Since(start))
 	span.AddEvent("finished OFAC preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from US OFAC")
 	}
 
@@ -92,7 +92,7 @@ func loadUSNonSDNRecords(ctx context.Context, logger log.Logger, conf Config, re
 	logger.Debug().Logf("finished US Non-SDN preparation: %v", time.Since(start))
 	span.AddEvent("finished US Non-SDN preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from US Non-SDN")
 	}
 
@@ -135,7 +135,7 @@ func loadCSLUSRecords(ctx context.Context, logger log.Logger, conf Config, respo
 	logger.Debug().Logf("finished US CSL preparation: %v", time.Since(start))
 	span.AddEvent("finished US CSL preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from US CSL")
 	}
 

--- a/internal/download/download_us_tel.go
+++ b/internal/download/download_us_tel.go
@@ -71,7 +71,7 @@ func loadUSTelRecords(ctx context.Context, logger log.Logger, conf Config, respo
 	logger.Debug().Logf("finished US TEL preparation: %d entities in %v", len(entities), time.Since(start))
 	span.AddEvent("finished US TEL preparation")
 
-	if len(entities) == 0 && conf.ErrorOnEmptyList {
+	if len(entities) == 0 && errorOnEmptyList(conf) {
 		return errors.New("no entities parsed from US TEL")
 	}
 


### PR DESCRIPTION
Issue: https://github.com/moov-io/watchman/issues/856

`docs/config.md` lists `ERROR_ON_EMPTY_LIST` in the environment variables table, but nothing reads it. The only way to enable the empty-list check has been the `ErrorOnEmptyList` field in the YAML config. Setting the environment variable had no effect.

This adds `errorOnEmptyList(conf)` next to `initialDataDirectory(conf)` and uses it at each of the nine empty-list checks. When the environment variable is set it takes precedence over the YAML value, the same way `INITIAL_DATA_DIRECTORY` does. Values are parsed with `strx.Yes`, like `TFIDF_ENABLED` and `USE_SOUNDEX_MATCHING`.

## Not changed

- The default stays `false`. The issue also asks whether the default should be `true`; that is left to the discussion on the issue.
- `docs/config.md` already describes the variable and now matches the code.

## Tests

- `TestConfig_errorOnEmptyList` covers env unset, env only, YAML only, both set, env overriding YAML, blank env, and an unparsable value.
- `TestDownloader_RefreshAll_ErrorOnEmptyListFromEnv` runs `RefreshAll` against an empty Senzing file with the field unset, then sets the environment variable and expects the empty-list error.

🤖 claude
